### PR TITLE
5 display extended metadata

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ images = [
                 'sh'  : '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash -e'
         ],
         'debian9'    : [
-                'name': 'essdmscdm/debian9-build-node:2.1.0',
+                'name': 'essdmscdm/debian9-build-node:2.2.0',
                 'sh'  : 'bash -e'
         ],
         'ubuntu1804'  : [

--- a/src/ConnectKafka.cpp
+++ b/src/ConnectKafka.cpp
@@ -199,7 +199,7 @@ std::string ConnectKafka::showAllMetadata() {
   std::stringstream SS;
   SS << MetadataPointer->brokers()->size() << " brokers:\n";
   for (auto Broker : *MetadataPointer->brokers())
-    SS << "   broker " << Broker->id() << " at " << Broker->host()<<":"
+    SS << "   broker " << Broker->id() << " at " << Broker->host() << ":"
        << Broker->port() << "\n";
   SS << "\n";
   SS << MetadataPointer->topics()->size() << " topics:\n";

--- a/src/ConnectKafka.cpp
+++ b/src/ConnectKafka.cpp
@@ -199,7 +199,7 @@ std::string ConnectKafka::showAllMetadata() {
   std::stringstream SS;
   SS << MetadataPointer->brokers()->size() << " brokers:\n";
   for (auto Broker : *MetadataPointer->brokers())
-    SS << "   broker " << Broker->id() << " at " << Broker->host()
+    SS << "   broker " << Broker->id() << " at " << Broker->host()<<":"
        << Broker->port() << "\n";
   SS << "\n";
   SS << MetadataPointer->topics()->size() << " topics:\n";

--- a/src/ConnectKafka.h
+++ b/src/ConnectKafka.h
@@ -37,7 +37,11 @@ public:
 
   KafkaMessageMetadataStruct consumeLastNMessages() override;
 
-  std::vector<OffsetsStruct> getHighAndLowOffsets(std::string Topic) override;
+  std::vector<OffsetsStruct>
+  getTopicsHighAndLowOffsets(std::string Topic) override;
+
+  OffsetsStruct getPartitionHighAndLowOffsets(const std::string &Topic,
+                                              int32_t PartitionID) override;
 
   int getNumberOfTopicPartitions(std::string TopicName) override;
 

--- a/src/ConnectKafka.h
+++ b/src/ConnectKafka.h
@@ -45,4 +45,5 @@ public:
 
   void subscribeToLastNMessages(int64_t NMessages, const std::string &TopicName,
                                 int Partition) override;
+  std::string showAllMetadata() override;
 };

--- a/src/ConnectKafkaFake.cpp
+++ b/src/ConnectKafkaFake.cpp
@@ -14,12 +14,14 @@ KafkaMessageMetadataStruct ConnectKafkaFake::consumeFromOffset() {
 }
 
 std::vector<OffsetsStruct>
-ConnectKafkaFake::getHighAndLowOffsets(std::string Topic) {
+ConnectKafkaFake::getTopicsHighAndLowOffsets(std::string Topic) {
   std::vector<OffsetsStruct> VectorOfPartitions;
   OffsetsStruct FirstPartition = {1234, 12345, 0};
   OffsetsStruct SecondPartition{2234, 22345, 1};
+  OffsetsStruct ThirdPartition = getPartitionHighAndLowOffsets(Topic, 3);
   VectorOfPartitions.push_back(FirstPartition);
   VectorOfPartitions.push_back(SecondPartition);
+  VectorOfPartitions.push_back(ThirdPartition);
   return VectorOfPartitions;
 }
 
@@ -39,3 +41,13 @@ KafkaMessageMetadataStruct ConnectKafkaFake::consumeLastNMessages() {
 }
 
 std::string ConnectKafkaFake::showAllMetadata() { return "Test return"; }
+
+OffsetsStruct
+ConnectKafkaFake::getPartitionHighAndLowOffsets(const std::string &Topic,
+                                                int32_t PartitionID) {
+  OffsetsStruct OffsetsToReturn;
+  OffsetsToReturn.HighOffset = 5;
+  OffsetsToReturn.LowOffset = 1;
+  OffsetsToReturn.PartitionId = PartitionID;
+  return OffsetsToReturn;
+}

--- a/src/ConnectKafkaFake.cpp
+++ b/src/ConnectKafkaFake.cpp
@@ -38,6 +38,4 @@ KafkaMessageMetadataStruct ConnectKafkaFake::consumeLastNMessages() {
   return consumeFromOffset();
 }
 
-std::string ConnectKafkaFake::showAllMetadata() {
-  return std::__cxx11::string();
-}
+std::string ConnectKafkaFake::showAllMetadata() { return "Test return"; }

--- a/src/ConnectKafkaFake.cpp
+++ b/src/ConnectKafkaFake.cpp
@@ -37,3 +37,7 @@ void ConnectKafkaFake::subscribeToLastNMessages(int64_t NMessages,
 KafkaMessageMetadataStruct ConnectKafkaFake::consumeLastNMessages() {
   return consumeFromOffset();
 }
+
+std::string ConnectKafkaFake::showAllMetadata() {
+  return std::__cxx11::string();
+}

--- a/src/ConnectKafkaFake.h
+++ b/src/ConnectKafkaFake.h
@@ -16,7 +16,11 @@ public:
 
   KafkaMessageMetadataStruct consumeLastNMessages() override;
 
-  std::vector<OffsetsStruct> getHighAndLowOffsets(std::string Topic) override;
+  std::vector<OffsetsStruct>
+  getTopicsHighAndLowOffsets(std::string Topic) override;
+
+  OffsetsStruct getPartitionHighAndLowOffsets(const std::string &Topic,
+                                              int32_t PartitionID) override;
 
   int getNumberOfTopicPartitions(std::string TopicName) override;
 

--- a/src/ConnectKafkaFake.h
+++ b/src/ConnectKafkaFake.h
@@ -24,4 +24,5 @@ public:
 
   void subscribeToLastNMessages(int64_t NMessages, const std::string &TopicName,
                                 int Partition) override;
+  std::string showAllMetadata() override;
 };

--- a/src/ConnectKafkaInterface.h
+++ b/src/ConnectKafkaInterface.h
@@ -14,7 +14,10 @@ public:
   virtual KafkaMessageMetadataStruct consumeLastNMessages() = 0;
 
   virtual std::vector<OffsetsStruct>
-  getHighAndLowOffsets(std::string Topic) = 0;
+  getTopicsHighAndLowOffsets(std::string Topic) = 0;
+
+  virtual OffsetsStruct getPartitionHighAndLowOffsets(const std::string &Topic,
+                                                      int32_t PartitionID) = 0;
 
   virtual int getNumberOfTopicPartitions(std::string TopicName) = 0;
 

--- a/src/ConnectKafkaInterface.h
+++ b/src/ConnectKafkaInterface.h
@@ -23,4 +23,6 @@ public:
   virtual void subscribeToLastNMessages(int64_t NMessages,
                                         const std::string &TopicName,
                                         int Partition) = 0;
+
+  virtual std::string showAllMetadata() = 0;
 };

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -42,7 +42,7 @@ void RequestHandler::checkMetadataModeArguments(
     std::cout << KafkaConnection->showAllMetadata();
   else if (UserArguments.ShowAllTopics)
     std::cout << KafkaConnection->getAllTopics() << "\n";
-  if (UserArguments.ShowPartitionsOffsets)
+  else if (UserArguments.ShowPartitionsOffsets)
     showTopicPartitionOffsets(UserArguments);
 }
 

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -38,12 +38,12 @@ void RequestHandler::checkConsumerModeArguments(
 
 void RequestHandler::checkMetadataModeArguments(
     UserArgumentStruct UserArguments) {
-  if (!UserArguments.ShowAllTopics && !UserArguments.ShowPartitionsOffsets)
-    std::cout << KafkaConnection->showAllMetadata();
-  else if (UserArguments.ShowAllTopics)
+  if (UserArguments.ShowAllTopics)
     std::cout << KafkaConnection->getAllTopics() << "\n";
-  else if (UserArguments.ShowPartitionsOffsets)
+  else if (!UserArguments.Name.empty())
     showTopicPartitionOffsets(UserArguments);
+  else if (!UserArguments.ShowAllTopics)
+    std::cout << KafkaConnection->showAllMetadata();
 }
 
 void RequestHandler::subscribeConsumeAtOffset(std::string TopicName,
@@ -78,6 +78,7 @@ void RequestHandler::subscribeConsumeNLastMessages(std::string TopicName,
 
 void RequestHandler::showTopicPartitionOffsets(
     UserArgumentStruct UserArguments) {
+  std::cout << UserArguments.Name << "\n";
   for (auto &SingleStruct :
        KafkaConnection->getHighAndLowOffsets(UserArguments.Name)) {
     std::cout << "Partition ID: " << SingleStruct.PartitionId

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -39,7 +39,7 @@ void RequestHandler::checkConsumerModeArguments(
 void RequestHandler::checkMetadataModeArguments(
     UserArgumentStruct UserArguments) {
   if (!UserArguments.ShowAllTopics && !UserArguments.ShowPartitionsOffsets)
-    throw ArgumentsException("No action specified for \"--list\" mode");
+    std::cout << KafkaConnection->showAllMetadata();
   else if (UserArguments.ShowAllTopics)
     std::cout << KafkaConnection->getAllTopics() << "\n";
   if (UserArguments.ShowPartitionsOffsets)

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -80,7 +80,7 @@ void RequestHandler::showTopicPartitionOffsets(
     UserArgumentStruct UserArguments) {
   std::cout << UserArguments.Name << "\n";
   for (auto &SingleStruct :
-       KafkaConnection->getHighAndLowOffsets(UserArguments.Name)) {
+       KafkaConnection->getTopicsHighAndLowOffsets(UserArguments.Name)) {
     std::cout << "Partition ID: " << SingleStruct.PartitionId
               << " || Low offset: " << SingleStruct.LowOffset
               << " || High offset: " << SingleStruct.HighOffset << "\n";

--- a/src/UserArgumentsStruct.h
+++ b/src/UserArgumentsStruct.h
@@ -15,6 +15,5 @@ struct UserArgumentStruct {
   bool ShowAllTopics = false;
   bool ConsumerMode = false;
   bool MetadataMode = false;
-  bool ShowPartitionsOffsets = false;
   bool ShowEntireMessage = false;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,9 +31,8 @@ int main(int argc, char **argv) {
   App.add_flag("-C, --consumer", UserArguments.ConsumerMode,
                "Run the program in the consumer mode");
   App.add_flag("-L, --list", UserArguments.MetadataMode,
-               "Run the program in the metadata mode");
-  App.add_flag("-P, --partitions", UserArguments.ShowPartitionsOffsets,
-               "Show offsets for partitions of given topic \"-t\"");
+               "Metadata mode. Show all topics and partitions. If \"-t\" "
+               "specified, shows partition offsets.");
   App.add_flag("-E, --entire", UserArguments.ShowEntireMessage,
                "Show all records of a message(truncated by default)");
 

--- a/test/RequestHandlerTest.cpp
+++ b/test/RequestHandlerTest.cpp
@@ -87,7 +87,7 @@ TEST(RequestHandlerTest, show_all_topics_no_error) {
   RequestHandler NewRequestHandler(std::move(KafkaConnection), UserArguments);
   EXPECT_NO_THROW(NewRequestHandler.checkMetadataModeArguments(UserArguments));
 }
-TEST(RequestHandlerTest, no_action_specified_in_metadata_mode) {
+TEST(RequestHandlerTest, display_all_metadata) {
   auto KafkaConnection = std::make_unique<ConnectKafkaFake>(ConnectKafkaFake());
 
   UserArgumentStruct UserArguments;

--- a/test/RequestHandlerTest.cpp
+++ b/test/RequestHandlerTest.cpp
@@ -75,7 +75,8 @@ TEST(RequestHandlerTest, show_topic_partition_offsets_no_error) {
   auto KafkaConnection = std::make_unique<ConnectKafkaFake>(ConnectKafkaFake());
 
   UserArgumentStruct UserArguments;
-  UserArguments.ShowPartitionsOffsets = true;
+  UserArguments.Name = "MULTIPART_events";
+  UserArguments.ConsumerMode = true;
   RequestHandler NewRequestHandler(std::move(KafkaConnection), UserArguments);
   EXPECT_NO_THROW(NewRequestHandler.checkMetadataModeArguments(UserArguments));
 }
@@ -87,14 +88,17 @@ TEST(RequestHandlerTest, show_all_topics_no_error) {
   RequestHandler NewRequestHandler(std::move(KafkaConnection), UserArguments);
   EXPECT_NO_THROW(NewRequestHandler.checkMetadataModeArguments(UserArguments));
 }
+
 TEST(RequestHandlerTest, display_all_metadata) {
   auto KafkaConnection = std::make_unique<ConnectKafkaFake>(ConnectKafkaFake());
 
   UserArgumentStruct UserArguments;
   UserArguments.ShowAllTopics = false;
-  UserArguments.ShowPartitionsOffsets = false;
   RequestHandler NewRequestHandler(std::move(KafkaConnection), UserArguments);
-  EXPECT_NO_THROW(NewRequestHandler.checkMetadataModeArguments(UserArguments));
+  testing::internal::CaptureStdout();
+  NewRequestHandler.checkMetadataModeArguments(UserArguments);
+  std::string OutputMessage = testing::internal::GetCapturedStdout();
+  EXPECT_EQ("Test return", OutputMessage);
 }
 
 // consumer mode argument test

--- a/test/RequestHandlerTest.cpp
+++ b/test/RequestHandlerTest.cpp
@@ -94,8 +94,7 @@ TEST(RequestHandlerTest, no_action_specified_in_metadata_mode) {
   UserArguments.ShowAllTopics = false;
   UserArguments.ShowPartitionsOffsets = false;
   RequestHandler NewRequestHandler(std::move(KafkaConnection), UserArguments);
-  EXPECT_THROW(NewRequestHandler.checkMetadataModeArguments(UserArguments),
-               ArgumentsException);
+  EXPECT_NO_THROW(NewRequestHandler.checkMetadataModeArguments(UserArguments));
 }
 
 // consumer mode argument test


### PR DESCRIPTION
### Description of work
Consumer mode by default will display a detailed list of brokers, topics and partitions.


### Issue
Closes #5

### Acceptance Criteria
RequestHandler.cpp
ConnectKafka.cpp

### Unit Tests
Functionality entirely covered

### Other


```-b hinata.isis.cclrc.ac.uk:9092 -L ``` displays an extended list  **new functionality**
 ```-b hinata.isis.cclrc.ac.uk:9092 -L -t MULTIPART_events``` displays partitions' details for a specified topic
```-b hinata.isis.cclrc.ac.uk:9092 -L -a``` list all topics from the broker


---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).