### PR TITLE
42 indentation as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,18 @@ Client runs once and presents data as requested:
 bin/kafkacow -h
 
 Options:  
-    -h,--help                   Print this help message and exit
-    -g,--go INT                 How many records back to show from partition "-p". Mutually exclusive with "--Offset"
-    -t,--topic TEXT             Show records of specified topic
-    -b,--broker TEXT            Hostname or IP of Kafka broker
-    -o,--offset INT             Start consuming from an offset. Otherwise print entire topic. Mutually exclusive with "--go"
-    -p,--partition INT          Partition to get messages from
-    -a,--all                    Show a list of topics. To be used in "-L" mode.
-    -C,--consumer               Run the program in the consumer mode
-    -L,--list                   Metadata mode. Show all topics and partitions. If "-t" specified, shows partition offsets.
-    -E,--entire                 Show all records of a message(truncated by default)
-    -c,--config_file TEXT       Read configuration from an ini file
+     -h,--help                   Print this help message and exit
+     -g,--go INT                 How many records back to show from partition "-p". Mutually exclusive with "--Offset"
+     -t,--topic TEXT             Show records of specified topic
+     -b,--broker TEXT            Hostname or IP of Kafka broker
+     -o,--offset INT             Start consuming from an offset. Otherwise print entire topic. Mutually exclusive with "--go"
+     -p,--partition INT          Partition to get messages from
+     -i,--indentation INT        Number of spaces used as indentation. Range 0 - 20. 4 by default.
+     -a,--all                    Show a list of topics. To be used in "-L" mode.
+     -C,--consumer               Run the program in the consumer mode
+     -L,--list                   Metadata mode. Show all topics and partitions. If "-t" specified, shows partition offsets.
+     -E,--entire                 Show all records of a message(truncated by default)
+     -c,--config_file TEXT       Read configuration from an ini file
   ```
   
   #### Usage example

--- a/src/JSONPrinting.cpp
+++ b/src/JSONPrinting.cpp
@@ -8,7 +8,8 @@
 /// screen.
 ///
 /// \param JSONMessage
-std::string getEntireMessage(const std::string &JSONMessage) {
+std::string getEntireMessage(const std::string &JSONMessage,
+                             const int &Indent) {
   using std::cout;
   using nlohmann::json;
 
@@ -17,7 +18,7 @@ std::string getEntireMessage(const std::string &JSONMessage) {
   YAML::Emitter Emitter;
   Emitter << YAML::DoubleQuoted << YAML::Flow << node;
   auto JSONModernMessage = json::parse(Emitter.c_str());
-  std::string MessageWithNoQuotes = JSONModernMessage.dump(4);
+  std::string MessageWithNoQuotes = JSONModernMessage.dump(Indent);
   MessageWithNoQuotes.erase(
       std::remove(MessageWithNoQuotes.begin(), MessageWithNoQuotes.end(), '\"'),
       MessageWithNoQuotes.end());
@@ -31,7 +32,8 @@ std::string getEntireMessage(const std::string &JSONMessage) {
 /// it and prints it to the screen.
 ///
 /// \param JSONMessage
-std::string getTruncatedMessage(const std::string &JSONMessage) {
+std::string getTruncatedMessage(const std::string &JSONMessage,
+                                const int &Indent) {
   using std::cout;
   using nlohmann::json;
 
@@ -39,7 +41,7 @@ std::string getTruncatedMessage(const std::string &JSONMessage) {
   YAML::Emitter Emitter;
   Emitter << YAML::DoubleQuoted << YAML::Flow << Node;
   auto JSONModernMessage = json::parse(Emitter.c_str());
-  std::string MessageWithNoQuotes = JSONModernMessage.dump(4);
+  std::string MessageWithNoQuotes = JSONModernMessage.dump(Indent);
   MessageWithNoQuotes.erase(
       std::remove(MessageWithNoQuotes.begin(), MessageWithNoQuotes.end(), '\"'),
       MessageWithNoQuotes.end());

--- a/src/JSONPrinting.h
+++ b/src/JSONPrinting.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "UserArgumentsStruct.h"
 #include <string>
 #include <yaml-cpp/yaml.h>
 
-std::string getEntireMessage(const std::string &JSONMessage);
-std::string getTruncatedMessage(const std::string &JSONMessage);
+std::string getEntireMessage(const std::string &JSONMessage, const int &Indent);
+std::string getTruncatedMessage(const std::string &JSONMessage,
+                                const int &Indent);
 void recursiveTruncateJSONMap(YAML::Node &Node);
 void recursiveTruncateJSONSequence(YAML::Node &Node);
 YAML::Node truncateMessage(const std::string &JSONMessage);

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -161,8 +161,10 @@ void RequestHandler::consumePartitions(KafkaMessageMetadataStruct &MessageData,
   if (!MessageData.Payload.empty()) {
     std::string JSONMessage = FlatBuffers.deserializeToYAML(MessageData);
     (UserArguments.ShowEntireMessage)
-        ? printToScreen(getEntireMessage(JSONMessage))
-        : printToScreen(getTruncatedMessage(JSONMessage));
+        ? printToScreen(
+              getEntireMessage(JSONMessage, UserArguments.Indentation))
+        : printToScreen(
+              getTruncatedMessage(JSONMessage, UserArguments.Indentation));
   }
   if (MessageData.PartitionEOF)
     EOFPartitionCounter++;

--- a/src/UserArgumentsStruct.h
+++ b/src/UserArgumentsStruct.h
@@ -11,6 +11,7 @@ struct UserArgumentStruct {
   std::int64_t OffsetToStart = -2;
 
   int PartitionToConsume = -1;
+  int Indentation = 4;
 
   bool ShowAllTopics = false;
   bool ConsumerMode = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,10 @@ int main(int argc, char **argv) {
       ->check(CLI::Range(int64_t(0), std::numeric_limits<int64_t>::max()));
   App.add_option("-p,--partition", UserArguments.PartitionToConsume,
                  "Partition to get messages from");
+  App.add_option(
+         "-i,--indentation", UserArguments.Indentation,
+         "Number of spaces used as indentation. Range 0 - 20. 4 by default.")
+      ->check(CLI::Range(0, 20));
 
   App.add_flag("-a, --all", UserArguments.ShowAllTopics,
                "Show a list of topics. To be used in \"-L\" mode.");

--- a/test/JSONPrintingTest.cpp
+++ b/test/JSONPrintingTest.cpp
@@ -26,7 +26,6 @@ TEST(JSONPrintingTest, print_truncated_message_test) {
             "]\n}");
 }
 
-
 TEST(JSONPrintingTest, print_message_test) {
 
   testing::internal::CaptureStdout();

--- a/test/JSONPrintingTest.cpp
+++ b/test/JSONPrintingTest.cpp
@@ -26,6 +26,7 @@ TEST(JSONPrintingTest, print_truncated_message_test) {
             "]\n}");
 }
 
+
 TEST(JSONPrintingTest, print_message_test) {
 
   testing::internal::CaptureStdout();

--- a/test/JSONPrintingTest.cpp
+++ b/test/JSONPrintingTest.cpp
@@ -8,8 +8,8 @@ class JSONPrintingTest : public ::testing::Test {};
 
 TEST(JSONPrintingTest, print_entire_message_test) {
   std::string InputMessage = "{\n  source_name: \"NeXus-Streamer\"}";
-  EXPECT_EQ(getEntireMessage(InputMessage), "{\n    source_name: "
-                                            "NeXus-Streamer\n}");
+  EXPECT_EQ(getEntireMessage(InputMessage, 4), "{\n    source_name: "
+                                               "NeXus-Streamer\n}");
 }
 
 TEST(JSONPrintingTest, print_truncated_message_test) {
@@ -18,7 +18,7 @@ TEST(JSONPrintingTest, print_truncated_message_test) {
       "32972,\n    79344,\n    22827,\n    32972,\n    79344,\n    22827,\n    "
       "32972,\n    79344,\n    22827,\n    32972,\n    79344,\n    22827,\n    "
       "37233,\n]}";
-  EXPECT_EQ(getTruncatedMessage(InputMessage),
+  EXPECT_EQ(getTruncatedMessage(InputMessage, 4),
             "{\n    time_of_flight: [\n        15579\n        91072\n        "
             "32972\n        79344\n        22827\n        32972\n        "
             "79344\n        22827\n        32972\n        79344\n        "
@@ -41,5 +41,5 @@ TEST(JSONPrintingTest, print_nested_maps_and_sequences_test) {
                              "  32972: {\n"
                              "    32972:\n"
                              "    32972}},[15579, 91072] ]";
-  EXPECT_NO_THROW(getTruncatedMessage(InputMessage));
+  EXPECT_NO_THROW(getTruncatedMessage(InputMessage, 4));
 }


### PR DESCRIPTION
### Description of work

Indentation can be now passed as an ```-i``` argument. The range is set from 0 to 20 to prevent accidental input of large numbers. Default is 4, which seems to be the most reasonable size.

### Issue

Closes #42 

### Acceptance Criteria

main.cpp
JSONPrinting.cpp
RequestHandler.cpp

### Unit Tests

Modified few unit tests in JSONPrintingTest.cpp

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).