### PR TITLE
32 consume range

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ Client runs once and presents data as requested:
 ```
 bin/kafkacow -h
 
-Options:  
+Options:
   -h,--help                   Print this help message and exit
   -C,--consumer               Run the program in the consumer mode.
   -L,--list                   Metadata mode. Show all topics and partitions. If "-t" specified, shows partition offsets.
   -b,--broker TEXT            Hostname or IP of Kafka broker.
   -t,--topic TEXT             Show records of specified topic.
   -p,--partition INT          Partition to get messages from.
-  -g,--go INT                 How many records back to show from partition "-p". Mutually exclusive with "--Offset".
-  -o,--offset INT             Start consuming from an offset. Otherwise print entire topic. Mutually exclusive with "--go".
+  -g,--go INT                 How many records back to show from partition "-p". To display range of messages combine with "-o" as lower offset.
+  -o,--offset INT             Start consuming from an offset. Combine with "-g" to display range of messages with "-o" as lower offset.
   -i,--indentation INT        Number of spaces used as indentation. Range 0 - 20. 4 by default.
   -a,--all                    Show a list of topics. To be used in "-L" mode.
   -e,--entire                 Show all records of a message(truncated by default).
-  -c,--config-file TEXT            Read configuration from an ini file.
+  -c,--config-file TEXT       Read configuration from an ini file.
   ```
   
   #### Usage example
@@ -34,6 +34,11 @@ bin/kafkacow -b hinata.isis.cclrc.ac.uk:9092 -C -g 10 -t MULTIPART_events
   Show list of all topics from broker hinata.isis.cclrc.ac.uk:9092:
   ```
  bin/kafkacow -b hinata.isis.cclrc.ac.uk:9092 -L -a
+  ```
+  
+  Starting at offset 1500 show 10 messages from topic MULTIPART_events from broker hinata.isis.cclrc.ac.uk:9092:
+  ```
+  bin/kafkacow -b hinata.isis.cclrc.ac.uk:9092 -C -t MULTIPART_events -o 1500 -g 10
   ```
   
   ## Install

--- a/src/ConnectKafkaFake.cpp
+++ b/src/ConnectKafkaFake.cpp
@@ -18,7 +18,7 @@ ConnectKafkaFake::getTopicsHighAndLowOffsets(const std::string &Topic) {
 
   std::vector<OffsetsStruct> VectorOfPartitions;
 
-  if(Topic!="EmptyTopic") {
+  if (Topic != "EmptyTopic") {
     OffsetsStruct FirstPartition = {1234, 12345, 0};
     OffsetsStruct SecondPartition{2234, 22345, 1};
     OffsetsStruct ThirdPartition = getPartitionHighAndLowOffsets(Topic, 3);

--- a/src/ConnectKafkaFake.cpp
+++ b/src/ConnectKafkaFake.cpp
@@ -15,13 +15,17 @@ KafkaMessageMetadataStruct ConnectKafkaFake::consumeFromOffset() {
 
 std::vector<OffsetsStruct>
 ConnectKafkaFake::getTopicsHighAndLowOffsets(const std::string &Topic) {
+
   std::vector<OffsetsStruct> VectorOfPartitions;
-  OffsetsStruct FirstPartition = {1234, 12345, 0};
-  OffsetsStruct SecondPartition{2234, 22345, 1};
-  OffsetsStruct ThirdPartition = getPartitionHighAndLowOffsets(Topic, 3);
-  VectorOfPartitions.push_back(FirstPartition);
-  VectorOfPartitions.push_back(SecondPartition);
-  VectorOfPartitions.push_back(ThirdPartition);
+
+  if(Topic!="EmptyTopic") {
+    OffsetsStruct FirstPartition = {1234, 12345, 0};
+    OffsetsStruct SecondPartition{2234, 22345, 1};
+    OffsetsStruct ThirdPartition = getPartitionHighAndLowOffsets(Topic, 3);
+    VectorOfPartitions.push_back(FirstPartition);
+    VectorOfPartitions.push_back(SecondPartition);
+    VectorOfPartitions.push_back(ThirdPartition);
+  }
   return VectorOfPartitions;
 }
 

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -27,17 +27,16 @@ void RequestHandler::checkAndRun() {
 /// \param UserArguments
 void RequestHandler::checkConsumerModeArguments(
     UserArgumentStruct UserArguments) {
-  if (UserArguments.GoBack > -2 && UserArguments.OffsetToStart > -2)
-    throw ArgumentsException("Program must take one and only one of the "
-                             "arguments: \"--go\",\"--Offset\"");
-  else if (UserArguments.GoBack == -2 && UserArguments.OffsetToStart == -2 &&
-           UserArguments.Name.empty()) {
+  if (UserArguments.GoBack == -2 && UserArguments.OffsetToStart == -2 &&
+      UserArguments.Name.empty()) {
     throw ArgumentsException("Please specify topic!");
   }
-  // check if topic is not empty
   checkIfTopicEmpty(UserArguments.Name);
   if (UserArguments.GoBack == -2 && UserArguments.OffsetToStart == -2) {
     printEntireTopic(UserArguments.Name);
+  } else if (UserArguments.GoBack > -2 && UserArguments.OffsetToStart > -2) {
+    subscribeConsumeRange(UserArguments.OffsetToStart, UserArguments.GoBack,
+                          UserArguments.PartitionToConsume, UserArguments.Name);
   } else {
     if (UserArguments.OffsetToStart > -2) {
       subscribeConsumeAtOffset(UserArguments.Name, UserArguments.OffsetToStart);
@@ -48,6 +47,31 @@ void RequestHandler::checkConsumerModeArguments(
                                           UserArguments.PartitionToConsume)
           : Logger->error("Please specify partition");
     }
+  }
+}
+
+void RequestHandler::subscribeConsumeRange(const int64_t &Offset,
+                                           const int64_t &NumberOfMessages,
+                                           const int &Partition,
+                                           const std::string &TopicName) {
+  if (verifyOffset(Offset, TopicName))
+    throw ArgumentsException("Lower offset not valid!");
+  if (verifyOffset(Offset + NumberOfMessages, TopicName))
+    throw ArgumentsException("Cannot show that many messages!");
+
+  int EOFPartitionCounter = 0;
+  int NumberOfPartitions =
+      KafkaConnection->getNumberOfTopicPartitions(TopicName);
+
+  KafkaConnection->subscribeAtOffset(Offset, TopicName);
+  FlatbuffersTranslator FlatBuffers;
+  int MessagesCounter = 0;
+  while (EOFPartitionCounter < NumberOfPartitions &&
+         MessagesCounter <= NumberOfMessages) {
+    KafkaMessageMetadataStruct MessageData;
+    MessageData = KafkaConnection->consumeFromOffset();
+    consumePartitions(MessageData, EOFPartitionCounter, FlatBuffers);
+    MessagesCounter++;
   }
 }
 
@@ -83,7 +107,8 @@ void RequestHandler::checkMetadataModeArguments(
 /// \param Offset
 void RequestHandler::subscribeConsumeAtOffset(std::string TopicName,
                                               int64_t Offset) {
-  verifyOffset(Offset, TopicName);
+  if (!verifyOffset(Offset, TopicName))
+    throw ArgumentsException("Offset not valid!");
 
   int EOFPartitionCounter = 0;
   int NumberOfPartitions =
@@ -103,7 +128,7 @@ void RequestHandler::subscribeConsumeAtOffset(std::string TopicName,
 ///
 /// \param Offset
 /// \param TopicName
-void RequestHandler::verifyOffset(const int64_t Offset,
+bool RequestHandler::verifyOffset(const int64_t Offset,
                                   const std::string TopicName) {
   std::vector<OffsetsStruct> Offsets =
       KafkaConnection->getTopicsHighAndLowOffsets(TopicName);
@@ -114,8 +139,7 @@ void RequestHandler::verifyOffset(const int64_t Offset,
       break;
     }
   }
-  if (InvalidOffset)
-    throw ArgumentsException("Offset not valid!");
+  return InvalidOffset;
 }
 
 /// Subscribes to NumberOfMessages from Partition of specified TopicName and

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -107,7 +107,7 @@ void RequestHandler::checkMetadataModeArguments(
 /// \param Offset
 void RequestHandler::subscribeConsumeAtOffset(std::string TopicName,
                                               int64_t Offset) {
-  if (!verifyOffset(Offset, TopicName))
+  if (verifyOffset(Offset, TopicName))
     throw ArgumentsException("Offset not valid!");
 
   int EOFPartitionCounter = 0;

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -29,6 +29,11 @@ public:
   void subscribeConsumeNLastMessages(std::string TopicName,
                                      int64_t NumberOfMessages, int Partition);
 
+  void subscribeConsumeRange(const int64_t &Offset,
+                             const int64_t &NumberOfMessages,
+                             const int &Partition,
+                             const std::string &TopicName);
+
 private:
   std::shared_ptr<spdlog::logger> Logger;
   UserArgumentStruct UserArguments;
@@ -36,7 +41,7 @@ private:
   void consumePartitions(KafkaMessageMetadataStruct &MessageData,
                          int &EOFPartitionCounter,
                          FlatbuffersTranslator &FlatBuffers);
-  void verifyOffset(const int64_t Offset, const std::string TopicName);
+  bool verifyOffset(const int64_t Offset, const std::string TopicName);
   void verifyNLast(const int64_t NLast, const std::string TopicName,
                    const int16_t Partition);
   void printMessageMetadata(KafkaMessageMetadataStruct &MessageData);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,14 +23,14 @@ int main(int argc, char **argv) {
                  "Show records of specified topic.");
   App.add_option("-p,--partition", UserArguments.PartitionToConsume,
                  "Partition to get messages from.");
-  App.add_option(
-         "-g, --go", UserArguments.GoBack,
-         "How many records back to show from partition \"-p\". Mutually "
-         "exclusive with \"--Offset\".")
+  App.add_option("-g, --go", UserArguments.GoBack,
+                 "How many records back to show from partition \"-p\". To "
+                 "display range of messages combine with \"-o\" as lower "
+                 "offset.")
       ->check(CLI::Range(int64_t(0), std::numeric_limits<int64_t>::max()));
-  App.add_option(
-         "-o,--offset", UserArguments.OffsetToStart,
-         "Start consuming from an offset. Mutually exclusive with \"--go\"")
+  App.add_option("-o,--offset", UserArguments.OffsetToStart,
+                 "Start consuming from an offset. Combine with \"-g\" to "
+                 "display range of messages with \"-o\" as lower offset.")
       ->check(CLI::Range(int64_t(0), std::numeric_limits<int64_t>::max()));
   App.add_option(
          "-i,--indentation", UserArguments.Indentation,

--- a/test/RequestHandlerTest.cpp
+++ b/test/RequestHandlerTest.cpp
@@ -175,3 +175,45 @@ TEST(RequestHandlerTest,
   RequestHandler NewRequestHandler(std::move(KafkaConnection), UserArguments);
   EXPECT_NO_THROW(NewRequestHandler.checkConsumerModeArguments(UserArguments));
 }
+
+TEST(RequestHandlerTest, throw_error_when_lower_range_bound_incorrect) {
+  auto KafkaConnection = std::make_unique<ConnectKafkaFake>(ConnectKafkaFake());
+
+  UserArgumentStruct UserArguments;
+  UserArguments.OffsetToStart = 1233;
+  UserArguments.GoBack = 2;
+  RequestHandler NewRequestHandler(std::move(KafkaConnection), UserArguments);
+  EXPECT_THROW(NewRequestHandler.checkConsumerModeArguments(UserArguments),
+               ArgumentsException);
+}
+
+TEST(RequestHandlerTest, throw_error_when_upper_range_bound_incorrect) {
+  auto KafkaConnection = std::make_unique<ConnectKafkaFake>(ConnectKafkaFake());
+
+  UserArgumentStruct UserArguments;
+  UserArguments.OffsetToStart = 12344;
+  UserArguments.GoBack = 5;
+  RequestHandler NewRequestHandler(std::move(KafkaConnection), UserArguments);
+  EXPECT_THROW(NewRequestHandler.checkConsumerModeArguments(UserArguments),
+               ArgumentsException);
+}
+
+TEST(RequestHandlerTest, throw_error_no_topic_specified_in_consumer_mode) {
+  auto KafkaConnection = std::make_unique<ConnectKafkaFake>(ConnectKafkaFake());
+
+  UserArgumentStruct UserArguments;
+  RequestHandler NewRequestHandler(std::move(KafkaConnection), UserArguments);
+  EXPECT_THROW(NewRequestHandler.checkConsumerModeArguments(UserArguments),
+               ArgumentsException);
+}
+
+TEST(RequestHandlerTest, throw_error_if_topic_empty) {
+  auto KafkaConnection = std::make_unique<ConnectKafkaFake>(ConnectKafkaFake());
+
+  UserArgumentStruct UserArguments;
+  UserArguments.Name = "EmptyTopic";
+  UserArguments.GoBack = 5;
+  RequestHandler NewRequestHandler(std::move(KafkaConnection), UserArguments);
+  EXPECT_THROW(NewRequestHandler.checkConsumerModeArguments(UserArguments),
+               ArgumentsException);
+}

--- a/test/RequestHandlerTest.cpp
+++ b/test/RequestHandlerTest.cpp
@@ -125,15 +125,15 @@ TEST(RequestHandlerTest, display_all_metadata) {
 
 // consumer mode argument test
 
-TEST(RequestHandlerTest, both_goback_and_offsettostart_specified_error) {
+TEST(RequestHandlerTest,
+     display_range_when_both_goback_and_offsettostart_specified) {
   auto KafkaConnection = std::make_unique<ConnectKafkaFake>(ConnectKafkaFake());
 
   UserArgumentStruct UserArguments;
   UserArguments.OffsetToStart = 1234;
-  UserArguments.GoBack = 1234;
+  UserArguments.GoBack = 2;
   RequestHandler NewRequestHandler(std::move(KafkaConnection), UserArguments);
-  EXPECT_THROW(NewRequestHandler.checkConsumerModeArguments(UserArguments),
-               ArgumentsException);
+  EXPECT_NO_THROW(NewRequestHandler.checkConsumerModeArguments(UserArguments));
 }
 
 TEST(RequestHandlerTest, subscribe_to_nlastmessages_no_error) {

--- a/test/RequestHandlerTest.cpp
+++ b/test/RequestHandlerTest.cpp
@@ -191,7 +191,7 @@ TEST(RequestHandlerTest, throw_error_when_upper_range_bound_incorrect) {
   auto KafkaConnection = std::make_unique<ConnectKafkaFake>(ConnectKafkaFake());
 
   UserArgumentStruct UserArguments;
-  UserArguments.OffsetToStart = 12344;
+  UserArguments.OffsetToStart = 22343;
   UserArguments.GoBack = 5;
   RequestHandler NewRequestHandler(std::move(KafkaConnection), UserArguments);
   EXPECT_THROW(NewRequestHandler.checkConsumerModeArguments(UserArguments),


### PR DESCRIPTION
### Description of work

User can now call program with both `-o` and `g` specified to display range of messages, e.g.
`-b hinata.isis.cclrc.ac.uk:9092 -C -t SANS2D_runInfo -o 14 -g 4`
which would consume 4 messages starting at offset 14.

### Issue

Closes #32 

### Acceptance Criteria
RequestHandler.cpp
RequestHandlerTests.cpp

### Unit Tests

Tests written  or updated in RequestHandlerTests.cpp to cover new methods and error throwing blocks.


---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).