### PR TITLE
re #60 throw error if topic not found

### DIFF
--- a/src/ConnectKafka.cpp
+++ b/src/ConnectKafka.cpp
@@ -133,21 +133,32 @@ KafkaMessageMetadataStruct ConnectKafka::consume() {
 /// \return vector<int32_t> of partition IDs
 std::vector<int32_t>
 ConnectKafka::getTopicPartitionNumbers(const std::string &Topic) {
-  auto Metadata = queryMetadata();
-  auto Topics = Metadata->topics();
-  auto Iterator = std::find_if(Topics->cbegin(), Topics->cend(),
-                               [Topic](const RdKafka::TopicMetadata *tpc) {
-                                 return tpc->topic() == Topic;
-                               });
-  auto matchedTopic = *Iterator;
+  auto TopicMetadata = getTopicMetadata(Topic);
   std::vector<int32_t> TopicPartitionNumbers;
-  auto PartitionMetadata = matchedTopic->partitions();
+  auto PartitionMetadata = TopicMetadata->partitions();
   // save needed partition metadata here
   for (auto &Partition : *PartitionMetadata) {
     TopicPartitionNumbers.push_back(Partition->id());
   }
   sort(TopicPartitionNumbers.begin(), TopicPartitionNumbers.end());
   return TopicPartitionNumbers;
+}
+/// Searches for Topic metadata. Throws an error, if topic not found.
+///
+/// \param Topic
+/// return Pointer to RdKafka::TopicMetadata.
+const RdKafka::TopicMetadata *
+ConnectKafka::getTopicMetadata(const std::string &Topic) {
+  auto Metadata = queryMetadata();
+  auto Topics = Metadata->topics();
+  auto Iterator = std::find_if(Topics->cbegin(), Topics->cend(),
+                               [Topic](const RdKafka::TopicMetadata *tpc) {
+                                 return tpc->topic() == Topic;
+                               });
+  auto MatchedTopic = *Iterator;
+  if (MatchedTopic == nullptr)
+    throw ArgumentException(fmt::format("No such topic: {}", Topic));
+  return MatchedTopic;
 }
 
 /// Returns a vector of structs containing offsets of partitions for specified

--- a/src/ConnectKafka.h
+++ b/src/ConnectKafka.h
@@ -44,6 +44,8 @@ private:
   std::unique_ptr<RdKafka::Metadata> MetadataPointer;
   std::shared_ptr<spdlog::logger> Logger;
 
+  const RdKafka::TopicMetadata *getTopicMetadata(const std::string &Topic);
+
   std::unique_ptr<RdKafka::Metadata> queryMetadata();
 
   std::vector<int32_t> getTopicPartitionNumbers(const std::string &Topic);


### PR DESCRIPTION
### Description of work

Refactored method `ConnectKafka::getTopicPartitionNumbers` into two methods, one of which throws an exception if requested Topic is not found

### Issue

Closes #60 

### Acceptance Criteria

run kafkacow with `-C -b hinata -t TopicThatShouldNotBe -o 2384 -g 10`

### Unit Tests

n/a

### Other

n/a

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).