### PR TITLE
Display flatbuffer file identifier for each message

### DIFF
--- a/src/FlatbuffersTranslator.cpp
+++ b/src/FlatbuffersTranslator.cpp
@@ -8,18 +8,21 @@
 ///
 /// \param Message
 /// \return single string with YAML/JSON message.
-std::string FlatbuffersTranslator::deserializeToYAML(
-    KafkaMessageMetadataStruct MessageData) {
+std::string
+FlatbuffersTranslator::deserializeToYAML(KafkaMessageMetadataStruct MessageData,
+                                         std::string &FileID) {
   // get the ID from a message
-  std::string FileID = MessageData.Payload.substr(4, 4);
+  FileID = MessageData.Payload.substr(4, 4);
   if (FileIDMap.find(FileID) ==
       FileIDMap.end()) { // if no ID present in the map:
 
     std::pair<bool, std::string> SchemaFile = getSchemaPathForID(FileID);
 
     // if FileID is invalid, assume message is in JSON and return it
-    if (!SchemaFile.first)
+    if (!SchemaFile.first) {
+      FileID = FileID + " (not recognised)";
       return MessageData.Payload;
+    }
 
     std::string Schema;
     bool ok = flatbuffers::LoadFile(SchemaFile.second.c_str(), false, &Schema);

--- a/src/FlatbuffersTranslator.h
+++ b/src/FlatbuffersTranslator.h
@@ -9,7 +9,8 @@ class FlatbuffersTranslator {
 public:
   FlatbuffersTranslator() { Logger = spdlog::get("LOG"); }
 
-  std::string deserializeToYAML(KafkaMessageMetadataStruct MessageData);
+  std::string deserializeToYAML(KafkaMessageMetadataStruct MessageData,
+                                std::string &FileID);
 
   std::pair<bool, std::string> getSchemaPathForID(const std::string &FileID);
 

--- a/src/JSONPrinting.cpp
+++ b/src/JSONPrinting.cpp
@@ -1,7 +1,6 @@
 #include "JSONPrinting.h"
 #include <algorithm>
 #include <fmt/format.h>
-#include <iostream>
 #include <nlohmann/json.hpp>
 #include <yaml-cpp/yaml.h>
 
@@ -11,7 +10,6 @@
 /// \param JSONMessage
 std::string getEntireMessage(const std::string &JSONMessage,
                              const int &Indent) {
-  using std::cout;
   using nlohmann::json;
 
   // convert into valid JSON
@@ -35,7 +33,6 @@ std::string getEntireMessage(const std::string &JSONMessage,
 /// \param JSONMessage
 std::string getTruncatedMessage(const std::string &JSONMessage,
                                 const int &Indent) {
-  using std::cout;
   using nlohmann::json;
 
   YAML::Node Node = truncateMessage(JSONMessage);

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -83,7 +83,7 @@ void RequestHandler::checkMetadataModeArguments(
 /// \param Offset
 /// \param TopicName
 bool RequestHandler::verifyOffset(const int64_t Offset,
-                                  const std::string TopicName) {
+                                  const std::string &TopicName) {
   std::vector<OffsetsStruct> Offsets =
       KafkaConnection->getTopicsHighAndLowOffsets(TopicName);
   bool InvalidOffset = true;
@@ -103,7 +103,7 @@ bool RequestHandler::verifyOffset(const int64_t Offset,
 /// \param TopicName
 /// \param Partition
 void RequestHandler::verifyNLast(const int64_t NLast,
-                                 const std::string TopicName,
+                                 const std::string &TopicName,
                                  const int16_t Partition) {
   OffsetsStruct Struct =
       KafkaConnection->getPartitionHighAndLowOffsets(TopicName, Partition);
@@ -135,8 +135,10 @@ void RequestHandler::printKafkaMessage(KafkaMessageMetadataStruct &MessageData,
                                        int &EOFPartitionCounter,
                                        FlatbuffersTranslator &FlatBuffers) {
   if (!MessageData.Payload.empty()) {
-    std::string JSONMessage = FlatBuffers.deserializeToYAML(MessageData);
-    printMessageMetadata(MessageData);
+    std::string FileIdentifier;
+    std::string JSONMessage =
+        FlatBuffers.deserializeToYAML(MessageData, FileIdentifier);
+    printMessageMetadata(MessageData, FileIdentifier);
     (UserArguments.ShowEntireMessage)
         ? std::cout << fmt::format(
               "{}", getEntireMessage(JSONMessage, UserArguments.Indentation))
@@ -152,12 +154,13 @@ void RequestHandler::printKafkaMessage(KafkaMessageMetadataStruct &MessageData,
 ///
 /// \param MessageData
 void RequestHandler::printMessageMetadata(
-    KafkaMessageMetadataStruct &MessageData) {
+    KafkaMessageMetadataStruct &MessageData,
+    const std::string &FileIdentifier) {
   std::cout << fmt::format(
       "\n{:_>67}{}{:>39}\n\nTimestamp: {:>11} || PartitionID: "
-      "{:>5} || Offset: {:>7}\n",
+      "{:>5} || Offset: {:>7} || File Identifier: {}\n",
       "\n", MessageData.TimestampISO, "|", MessageData.Timestamp,
-      MessageData.Partition, MessageData.Offset);
+      MessageData.Partition, MessageData.Offset, FileIdentifier);
 }
 
 /// Calculates topic's lowest offset and subscribes to it to print the entire

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -40,10 +40,11 @@ private:
   void printKafkaMessage(KafkaMessageMetadataStruct &MessageData,
                          int &EOFPartitionCounter,
                          FlatbuffersTranslator &FlatBuffers);
-  bool verifyOffset(const int64_t Offset, const std::string TopicName);
-  void verifyNLast(const int64_t NLast, const std::string TopicName,
-                   const int16_t Partition);
-  void printMessageMetadata(KafkaMessageMetadataStruct &MessageData);
+  bool verifyOffset(int64_t Offset, const std::string &TopicName);
+  void verifyNLast(int64_t NLast, const std::string &TopicName,
+                   int16_t Partition);
+  void printMessageMetadata(KafkaMessageMetadataStruct &MessageData,
+                            const std::string &FileIdentifier);
   void printEntireTopic(const std::string &TopicName);
   void checkIfTopicEmpty(const std::string &TopicName);
   std::string timestampToReadable(const int64_t &Timestamp);

--- a/test/FlatbuffersTranslatorTest.cpp
+++ b/test/FlatbuffersTranslatorTest.cpp
@@ -6,8 +6,9 @@
 class FlatbuffersTranslatorTest : public ::testing::Test {
 
 public:
-  static std::string getStringToCompare(std::string Source, std::string Value,
-                                        std::string TimeStamp) {
+  static std::string getStringToCompare(const std::string &Source,
+                                        const std::string &Value,
+                                        const std::string &TimeStamp) {
     std::string ToCompare = R"({
   source_name: ")";
     ToCompare.append(Source);
@@ -51,8 +52,9 @@ TEST(FlatbuffersTranslatorTest, translate_flatbuffers_test) {
   FlatbuffersTranslator FlatBuffersTranslator;
 
   // Run first time to populate schema map
-  FlatBuffersTranslator.deserializeToYAML(MessageMetadata);
-  EXPECT_EQ(FlatBuffersTranslator.deserializeToYAML(MessageMetadata),
+  std::string FileID;
+  FlatBuffersTranslator.deserializeToYAML(MessageMetadata, FileID);
+  EXPECT_EQ(FlatBuffersTranslator.deserializeToYAML(MessageMetadata, FileID),
             FlatbuffersTranslatorTest::getStringToCompare(
                 SourceNameCompare, ValueCompare, TimeStampCompare));
 }
@@ -61,6 +63,7 @@ TEST(FlatbuffersTranslatorTest, message_already_in_json_test) {
   KafkaMessageMetadataStruct MessageMetadata;
   MessageMetadata.Payload = "{\n  source_name: \"NeXus-Streamer\"}";
   FlatbuffersTranslator FlatBuffersTranslator;
-  EXPECT_EQ(FlatBuffersTranslator.deserializeToYAML(MessageMetadata),
+  std::string FileID;
+  EXPECT_EQ(FlatBuffersTranslator.deserializeToYAML(MessageMetadata, FileID),
             MessageMetadata.Payload);
 }


### PR DESCRIPTION
Closes #62

Displays the file identifer for each message. If the file identifier is unknown then it appends `(not recognised)` when it prints the identifier.