### PR TITLE
re #71 add boolean flag to prevent tests from looping

### DIFF
--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -26,14 +26,15 @@ void RequestHandler::checkAndRun() {
 /// run.
 ///
 /// \param UserArguments
+/// \param TerminateAtEndOfTopic terminate at end of topic. For unit tests.
 void RequestHandler::checkConsumerModeArguments(
-    UserArgumentStruct UserArguments) {
+    UserArgumentStruct UserArguments, bool TerminateAtEndOfTopic) {
   if (UserArguments.GoBack == -2 && UserArguments.OffsetToStart == -2 &&
       UserArguments.Name.empty()) {
     throw ArgumentException("Please specify topic!");
   }
   if (UserArguments.GoBack == -2 && UserArguments.OffsetToStart == -2) {
-    printEntireTopic(UserArguments.Name);
+    printEntireTopic(UserArguments.Name, TerminateAtEndOfTopic);
   } else {
     checkIfTopicEmpty(UserArguments.Name);
     if (UserArguments.GoBack > -2 && UserArguments.OffsetToStart > -2) {
@@ -169,7 +170,9 @@ void RequestHandler::printMessageMetadata(
 /// topic.
 ///
 /// \param TopicName
-void RequestHandler::printEntireTopic(const std::string &TopicName) {
+/// \param TerminateAtEndOfTopic terminate at end of topic. For unit tests.
+void RequestHandler::printEntireTopic(const std::string &TopicName,
+                                      bool TerminateAtEndOfTopic) {
   std::vector<OffsetsStruct> OffsetsStruct =
       KafkaConnection->getTopicsHighAndLowOffsets(TopicName);
   int64_t MinOffset = OffsetsStruct[0].LowOffset;
@@ -177,7 +180,7 @@ void RequestHandler::printEntireTopic(const std::string &TopicName) {
     if (OffsetStruct.LowOffset < MinOffset)
       MinOffset = OffsetStruct.LowOffset;
   }
-  subscribeAndConsume(TopicName, MinOffset);
+  subscribeAndConsume(TopicName, MinOffset, TerminateAtEndOfTopic);
 }
 
 std::string RequestHandler::timestampToReadable(const int64_t &Timestamp) {

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -17,7 +17,8 @@ public:
 
   void checkAndRun();
 
-  void checkConsumerModeArguments(UserArgumentStruct UserArguments);
+  void checkConsumerModeArguments(UserArgumentStruct UserArguments,
+                                  bool TerminateAtEndOfTopic = false);
 
   void checkMetadataModeArguments(UserArgumentStruct UserArguments);
 
@@ -45,7 +46,8 @@ private:
                    int16_t Partition);
   void printMessageMetadata(KafkaMessageMetadataStruct &MessageData,
                             const std::string &FileIdentifier);
-  void printEntireTopic(const std::string &TopicName);
+  void printEntireTopic(const std::string &TopicName,
+                        bool TerminateAtEndOfTopic = false);
   void checkIfTopicEmpty(const std::string &TopicName);
   std::string timestampToReadable(const int64_t &Timestamp);
   bool consumeSingleMessage(int &EOFPartitionCounter,

--- a/test/RequestHandlerTest.cpp
+++ b/test/RequestHandlerTest.cpp
@@ -224,3 +224,14 @@ TEST(RequestHandlerTest, throw_error_if_topic_empty) {
   EXPECT_THROW(NewRequestHandler.checkConsumerModeArguments(UserArguments),
                ArgumentException);
 }
+
+TEST(RequestHandlerTest, print_entire_topic_success) {
+  auto KafkaConnection = std::make_unique<ConnectKafkaFake>(ConnectKafkaFake());
+
+  UserArgumentStruct UserArguments;
+  UserArguments.Name = "TestTopic";
+  RequestHandler NewRequestHandler(std::move(KafkaConnection), UserArguments,
+                                   getSchemaPath());
+  EXPECT_NO_THROW(
+      NewRequestHandler.checkConsumerModeArguments(UserArguments, true));
+}


### PR DESCRIPTION
### Description of work

`RequestHandler::printEntireTopic` and its invocation in `RequestHandler::checkConsumerModeArguments` are now tested. 

### Issue
Closes #71 
### Acceptance Criteria

Introduced boolean argument in these methods to prevent tests from entering infinite loop while consuming fake messages.

### Unit Tests
new `RequestHandlerTest::print_entire_topic_success`

### Other

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).