### PR TITLE
80 display empty json arrays

### DIFF
--- a/src/FlatbuffersTranslator.cpp
+++ b/src/FlatbuffersTranslator.cpp
@@ -67,7 +67,7 @@ std::pair<bool, std::string>
 FlatbuffersTranslator::getSchemaPathForID(const std::string &FileID) {
   if (FileID.empty())
     return std::make_pair(false, "");
-  
+
   boost::filesystem::directory_iterator DirectoryIterator(SchemaPath), e;
   std::vector<boost::filesystem::path> Paths(DirectoryIterator, e);
   for (auto &DirectoryEntry : Paths) {

--- a/src/FlatbuffersTranslator.cpp
+++ b/src/FlatbuffersTranslator.cpp
@@ -67,11 +67,11 @@ std::pair<bool, std::string>
 FlatbuffersTranslator::getSchemaPathForID(const std::string &FileID) {
   if (FileID.empty())
     return std::make_pair(false, "");
-
+  
   boost::filesystem::directory_iterator DirectoryIterator(SchemaPath), e;
   std::vector<boost::filesystem::path> Paths(DirectoryIterator, e);
   for (auto &DirectoryEntry : Paths) {
-    if (DirectoryEntry.string().find(FileID) != std::string::npos) {
+    if (DirectoryEntry.filename().string().find(FileID) != std::string::npos) {
       // if schema found, return TRUE and path
       return std::make_pair(true, DirectoryEntry.string());
     }

--- a/src/JSONPrinting.cpp
+++ b/src/JSONPrinting.cpp
@@ -54,9 +54,9 @@ std::string getTruncatedMessage(const std::string &JSONMessage,
 void recursiveTruncateJSONMap(nlohmann::json &JSONMessage) {
   for (nlohmann::json::iterator it = JSONMessage.begin();
        it != JSONMessage.end(); ++it) {
-    if (it.value().is_object()) {
+    if (it.value().is_object() && !it.value().empty()) {
       recursiveTruncateJSONMap(it.value());
-    } else if (it.value().is_array()) {
+    } else if (it.value().is_array() && !it.value().empty()) {
       recursiveTruncateJSONSequence(it.value());
     }
   }
@@ -72,9 +72,9 @@ void recursiveTruncateJSONSequence(nlohmann::json &JSONMessage) {
   for (nlohmann::json::iterator it = JSONMessage.end() - 1;
        it != JSONMessage.begin(); --it) {
     auto childNode = *it;
-    if (childNode.is_object()) {
+    if (childNode.is_object() && !childNode.empty()) {
       recursiveTruncateJSONMap(it.value());
-    } else if (childNode.is_array()) {
+    } else if (childNode.is_array() && !childNode.empty()) {
       recursiveTruncateJSONSequence(it.value());
     } else {
       Counter++;

--- a/src/JSONPrinting.cpp
+++ b/src/JSONPrinting.cpp
@@ -2,12 +2,13 @@
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
-/// Receives deserialized flatbuffers message, and prints it to screen according
-/// to Indent.
+/// Receives deserialized flatbuffers message, removes quotes and adds
+/// indentation for readability.
 ///
 /// \param JSONMessage
 /// \param Indent - number of characters of whitespace to use for indentation(4
 /// by default)
+/// \return readable message as string
 std::string getEntireMessage(const std::string &JSONMessage,
                              const int &Indent) {
   using nlohmann::json;
@@ -22,12 +23,13 @@ std::string getEntireMessage(const std::string &JSONMessage,
   return MessageWithNoQuotes;
 }
 
-/// Receives deserialized flatbuffers message, and prints it to screen according
-/// to Indent.
+/// Receives deserialized flatbuffers message, truncates, removes quotes and
+/// adds indentation for readability.
 ///
 /// \param JSONMessage
 /// \param Indent - number of characters of whitespace to use for indentation(4
 /// by default)
+/// \return truncated readable message as string
 std::string getTruncatedMessage(const std::string &JSONMessage,
                                 const int &Indent) {
 

--- a/test/JSONPrintingTest.cpp
+++ b/test/JSONPrintingTest.cpp
@@ -33,3 +33,19 @@ TEST(JSONPrintingTest, print_nested_maps_and_sequences_test) {
                              "    32972}},[15579, 91072] ]";
   EXPECT_NO_THROW(getTruncatedMessage(InputMessage, 4));
 }
+
+TEST(JSONPrintingTest, print_empty_arrays_empty_maps) {
+  std::string InputMessage = "{"
+                             "    \"emptyArray\":[],"
+                             "    \"emptyObject\": {}"
+                             "}";
+  EXPECT_NO_THROW(getTruncatedMessage(InputMessage, 4));
+}
+
+TEST(JSONPrintingTest, print_entire_message_empty_arrays_empty_maps) {
+  std::string InputMessage = "{"
+                             "    \"emptyArray\":[],"
+                             "    \"emptyObject\": {}"
+                             "}";
+  EXPECT_NO_THROW(getEntireMessage(InputMessage, 4));
+}


### PR DESCRIPTION
### Description of work

`FlatbuffersTranslator` now looks for SchemaID in schema filenames, not in full paths.
`JSONPrinting` recursive parsing methods now check for empty arrays and maps to avoid segfaults.

### Issue

Closes #80 