### PR TITLE
82 display non json

### DIFF
--- a/src/JSONPrinting.h
+++ b/src/JSONPrinting.h
@@ -12,3 +12,5 @@ std::string getTruncatedMessage(const std::string &JSONMessage,
 void recursiveTruncateJSONMap(nlohmann::json &JSONMessage);
 
 void recursiveTruncateJSONSequence(nlohmann::json &JSONMessage);
+
+std::string truncateNONJSON(const std::string &Message);

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -139,12 +139,14 @@ void RequestHandler::printKafkaMessage(KafkaMessageMetadataStruct &MessageData,
     std::string JSONMessage =
         FlatBuffers.deserializeToJSON(MessageData, FileIdentifier);
     printMessageMetadata(MessageData, FileIdentifier);
+
     (UserArguments.ShowEntireMessage)
         ? std::cout << fmt::format(
               "{}", getEntireMessage(JSONMessage, UserArguments.Indentation))
         : std::cout << fmt::format(
-              "{}",
-              getTruncatedMessage(JSONMessage, UserArguments.Indentation));
+                           "{}", getTruncatedMessage(JSONMessage,
+                                                     UserArguments.Indentation))
+                    << std::endl;
   }
   if (MessageData.PartitionEOF)
     EOFPartitionCounter++;

--- a/test/JSONPrintingTest.cpp
+++ b/test/JSONPrintingTest.cpp
@@ -57,8 +57,14 @@ TEST(JSONPrintingTest, print_entire_non_json) {
 }
 
 TEST(JSONPrintingTest, print_truncated_non_json) {
-  std::string InputMessage =
-      "This is not a json message and it should be displayed without parsing";
-  EXPECT_TRUE(InputMessage.find(getTruncatedMessage(InputMessage, 4)) !=
+  std::string LongMessage = "This is a message that should be long enough to "
+                            "truncate, and it is not JSON.";
+  EXPECT_TRUE(LongMessage.find(getTruncatedMessage(LongMessage, 4)) !=
+              std::string::npos);
+}
+
+TEST(JSONPrintingTest, print_non_json_too_short_to_truncate) {
+  std::string ShortMessage = "Too short";
+  EXPECT_TRUE(ShortMessage.find(getTruncatedMessage(ShortMessage, 4)) !=
               std::string::npos);
 }

--- a/test/JSONPrintingTest.cpp
+++ b/test/JSONPrintingTest.cpp
@@ -49,3 +49,16 @@ TEST(JSONPrintingTest, print_entire_message_empty_arrays_empty_maps) {
                              "}";
   EXPECT_NO_THROW(getEntireMessage(InputMessage, 4));
 }
+
+TEST(JSONPrintingTest, print_entire_non_json) {
+  std::string InputMessage =
+      "This is not a json message and it should be displayed without parsing";
+  EXPECT_EQ(getEntireMessage(InputMessage, 4), InputMessage);
+}
+
+TEST(JSONPrintingTest, print_truncated_non_json) {
+  std::string InputMessage =
+      "This is not a json message and it should be displayed without parsing";
+  EXPECT_TRUE(InputMessage.find(getTruncatedMessage(InputMessage, 4)) !=
+              std::string::npos);
+}


### PR DESCRIPTION
### Description of work

If parsing a message throws `nlohmann::json::exception` then this message is displayed without parsing.
If `-e` was chosen, entire message is displayed, if not, it is truncated to have a fixed number of characters.

### Issue
Closes #82 

### Unit Tests

Added two tests in `JSONPrintingTest.cpp` to test both alternatives.