### PR TITLE
93 offsets for times

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CMAKE_COMPILER_IS_GNUCXX AND COV)
 endif()
 
 set(CONAN_PACKAGES
-    CONAN_PKG::cli11
+    CONAN_PKG::CLI11
     CONAN_PKG::librdkafka
     CONAN_PKG::boost_filesystem
     CONAN_PKG::boost_system

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,8 @@ set(CONAN_PACKAGES
     CONAN_PKG::spdlog
     CONAN_PKG::jsonformoderncpp
     CONAN_PKG::libgit2
-    CONAN_PKG::streaming-data-types)
+    CONAN_PKG::streaming-data-types
+    CONAN_PKG::date)
 
 add_subdirectory(src)
 add_subdirectory(test)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-cli11/1.6.0@bincrafters/stable
+CLI11/1.6.0@bincrafters/stable
 flatbuffers/1.10.0@google/stable
 librdkafka/0.11.5-dm2@ess-dmsc/stable
 gtest/1.8.0@bincrafters/stable

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -11,6 +11,7 @@ jsonformoderncpp/3.2.0@vthiery/stable
 libgit2/0.27.4-dm1@ess-dmsc/stable
 fmt/5.2.0@bincrafters/stable
 streaming-data-types/c45d2ec@ess-dmsc/stable
+date/2.4.1@bincrafters/stable
 
 [generators]
 cmake

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-CLI11/1.6.0@bincrafters/stable
+CLI11/1.8.0@cliutils/stable
 flatbuffers/1.10.0@google/stable
 librdkafka/0.11.5-dm2@ess-dmsc/stable
 gtest/1.8.0@bincrafters/stable

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,4 +30,5 @@ add_executable(kafkacow main.cpp
 
 target_link_libraries(kafkacow
         ${CONAN_PACKAGES}
-        CONAN_PKG::fmt)
+        CONAN_PKG::fmt
+        CONAN_PKG::date)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,5 +30,4 @@ add_executable(kafkacow main.cpp
 
 target_link_libraries(kafkacow
         ${CONAN_PACKAGES}
-        CONAN_PKG::fmt
-        CONAN_PKG::date)
+        CONAN_PKG::fmt)

--- a/src/Kafka/Consumer.cpp
+++ b/src/Kafka/Consumer.cpp
@@ -277,6 +277,9 @@ long Consumer::isoDateToTimestamp(const std::string &Date) {
   std::istringstream ss(Date);
   std::chrono::system_clock::time_point tp;
   ss >> date::parse("%Y-%m-%dT%H:%M:%S", tp);
+  if (tp.time_since_epoch().count() == 0)
+    throw ArgumentException("Date not valid. Please use ISO8601 format, "
+                            "e.g.[2019-07-05T08:18:14.366].");
   return tp.time_since_epoch().count();
 }
 }

--- a/src/Kafka/Consumer.cpp
+++ b/src/Kafka/Consumer.cpp
@@ -2,6 +2,7 @@
 #include "../CustomExceptions.h"
 #include "KafkaConfig.h"
 #include "MessageMetadataStruct.h"
+#include <date/date.h>
 #include <iomanip>
 
 namespace Kafka {
@@ -254,5 +255,29 @@ std::string Consumer::showAllMetadata() {
     SS << "\n";
   }
   return SS.str();
+}
+
+int Consumer::subscribeToDate(const std::string &Topic,
+                              const std::string &isoDate) {
+  long Timestamp = isoDateToTimestamp(isoDate) / 1000000;
+  std::vector<RdKafka::TopicPartition *> TopicPartitionsWithOffsetsSet;
+  for (int i = 0; i < getNumberOfTopicPartitions(Topic); i++) {
+    auto TopicPartition = RdKafka::TopicPartition::create(Topic, i);
+    TopicPartition->set_offset(Timestamp);
+    TopicPartitionsWithOffsetsSet.push_back(TopicPartition);
+  }
+  KafkaConsumer->offsetsForTimes(TopicPartitionsWithOffsetsSet, 1000);
+  KafkaConsumer->assign(TopicPartitionsWithOffsetsSet);
+  std::for_each(TopicPartitionsWithOffsetsSet.cbegin(),
+                TopicPartitionsWithOffsetsSet.cend(),
+                [](RdKafka::TopicPartition *Partition) { delete Partition; });
+  return 666;
+}
+
+long Consumer::isoDateToTimestamp(const std::string &Date) {
+  std::istringstream ss(Date);
+  std::chrono::system_clock::time_point tp;
+  ss >> date::parse("%Y-%m-%dT%H:%M:%S", tp);
+  return tp.time_since_epoch().count();
 }
 }

--- a/src/Kafka/Consumer.cpp
+++ b/src/Kafka/Consumer.cpp
@@ -257,8 +257,8 @@ std::string Consumer::showAllMetadata() {
   return SS.str();
 }
 
-int Consumer::subscribeToDate(const std::string &Topic,
-                              const std::string &isoDate) {
+void Consumer::subscribeToDate(const std::string &Topic,
+                               const std::string &isoDate) {
   long Timestamp = isoDateToTimestamp(isoDate) / 1000000;
   std::vector<RdKafka::TopicPartition *> TopicPartitionsWithOffsetsSet;
   for (int i = 0; i < getNumberOfTopicPartitions(Topic); i++) {
@@ -271,7 +271,6 @@ int Consumer::subscribeToDate(const std::string &Topic,
   std::for_each(TopicPartitionsWithOffsetsSet.cbegin(),
                 TopicPartitionsWithOffsetsSet.cend(),
                 [](RdKafka::TopicPartition *Partition) { delete Partition; });
-  return 666;
 }
 
 long Consumer::isoDateToTimestamp(const std::string &Date) {

--- a/src/Kafka/Consumer.h
+++ b/src/Kafka/Consumer.h
@@ -43,8 +43,8 @@ public:
 
   std::string showAllMetadata() override;
 
-  void subscribeToDate(const std::string &Topic,
-                       const std::string &isoDate) override;
+  int64_t getOffsetForDate(const std::string &Date,
+                           const std::string &Topic) override;
 
 private:
   std::shared_ptr<RdKafka::KafkaConsumer> KafkaConsumer;

--- a/src/Kafka/Consumer.h
+++ b/src/Kafka/Consumer.h
@@ -43,6 +43,9 @@ public:
 
   std::string showAllMetadata() override;
 
+  int subscribeToDate(const std::string &Topic,
+                      const std::string &isoDate) override;
+
 private:
   std::shared_ptr<RdKafka::KafkaConsumer> KafkaConsumer;
   std::unique_ptr<RdKafka::Metadata> MetadataPointer;
@@ -53,5 +56,7 @@ private:
   std::unique_ptr<RdKafka::Metadata> queryMetadata();
 
   std::vector<int32_t> getTopicPartitionNumbers(const std::string &Topic);
+
+  long isoDateToTimestamp(const std::string &Date);
 };
 }

--- a/src/Kafka/Consumer.h
+++ b/src/Kafka/Consumer.h
@@ -43,8 +43,8 @@ public:
 
   std::string showAllMetadata() override;
 
-  int subscribeToDate(const std::string &Topic,
-                      const std::string &isoDate) override;
+  void subscribeToDate(const std::string &Topic,
+                       const std::string &isoDate) override;
 
 private:
   std::shared_ptr<RdKafka::KafkaConsumer> KafkaConsumer;

--- a/src/Kafka/ConsumerInterface.h
+++ b/src/Kafka/ConsumerInterface.h
@@ -32,7 +32,7 @@ public:
 
   virtual std::string showAllMetadata() = 0;
 
-  virtual void subscribeToDate(const std::string &Topic,
-                               const std::string &isoDate) = 0;
+  virtual int64_t getOffsetForDate(const std::string &Date,
+                                   const std::string &Topic) = 0;
 };
 }

--- a/src/Kafka/ConsumerInterface.h
+++ b/src/Kafka/ConsumerInterface.h
@@ -32,7 +32,7 @@ public:
 
   virtual std::string showAllMetadata() = 0;
 
-  virtual int subscribeToDate(const std::string &Topic,
-                              const std::string &isoDate) = 0;
+  virtual void subscribeToDate(const std::string &Topic,
+                               const std::string &isoDate) = 0;
 };
 }

--- a/src/Kafka/ConsumerInterface.h
+++ b/src/Kafka/ConsumerInterface.h
@@ -31,5 +31,8 @@ public:
                                         int Partition) = 0;
 
   virtual std::string showAllMetadata() = 0;
+
+  virtual int subscribeToDate(const std::string &Topic,
+                              const std::string &isoDate) = 0;
 };
 }

--- a/src/Kafka/FakeConsumer.cpp
+++ b/src/Kafka/FakeConsumer.cpp
@@ -58,6 +58,8 @@ FakeConsumer::getPartitionHighAndLowOffsets(const std::string &Topic,
   return OffsetsToReturn;
 }
 
-void FakeConsumer::subscribeToDate(const std::string &Topic,
-                                   const std::string &isoDate) {}
+int64_t FakeConsumer::getOffsetForDate(const std::string &Date,
+                                       const std::string &Topic) {
+  return 0;
+}
 }

--- a/src/Kafka/FakeConsumer.cpp
+++ b/src/Kafka/FakeConsumer.cpp
@@ -60,6 +60,6 @@ FakeConsumer::getPartitionHighAndLowOffsets(const std::string &Topic,
 
 int64_t FakeConsumer::getOffsetForDate(const std::string &Date,
                                        const std::string &Topic) {
-  return 0;
+  return 1;
 }
 }

--- a/src/Kafka/FakeConsumer.cpp
+++ b/src/Kafka/FakeConsumer.cpp
@@ -57,4 +57,9 @@ FakeConsumer::getPartitionHighAndLowOffsets(const std::string &Topic,
   OffsetsToReturn.PartitionId = PartitionID;
   return OffsetsToReturn;
 }
+
+int FakeConsumer::subscribeToDate(const std::string &Topic,
+                                  const std::string &isoDate) {
+  return 0;
+}
 }

--- a/src/Kafka/FakeConsumer.cpp
+++ b/src/Kafka/FakeConsumer.cpp
@@ -58,8 +58,6 @@ FakeConsumer::getPartitionHighAndLowOffsets(const std::string &Topic,
   return OffsetsToReturn;
 }
 
-int FakeConsumer::subscribeToDate(const std::string &Topic,
-                                  const std::string &isoDate) {
-  return 0;
-}
+void FakeConsumer::subscribeToDate(const std::string &Topic,
+                                   const std::string &isoDate) {}
 }

--- a/src/Kafka/FakeConsumer.h
+++ b/src/Kafka/FakeConsumer.h
@@ -31,7 +31,7 @@ public:
 
   std::string showAllMetadata() override;
 
-  int subscribeToDate(const std::string &Topic,
-                      const std::string &isoDate) override;
+  void subscribeToDate(const std::string &Topic,
+                       const std::string &isoDate) override;
 };
 }

--- a/src/Kafka/FakeConsumer.h
+++ b/src/Kafka/FakeConsumer.h
@@ -31,7 +31,7 @@ public:
 
   std::string showAllMetadata() override;
 
-  void subscribeToDate(const std::string &Topic,
-                       const std::string &isoDate) override;
+  int64_t getOffsetForDate(const std::string &Date,
+                           const std::string &Topic) override;
 };
 }

--- a/src/Kafka/FakeConsumer.h
+++ b/src/Kafka/FakeConsumer.h
@@ -30,5 +30,8 @@ public:
                                 int Partition) override;
 
   std::string showAllMetadata() override;
+
+  int subscribeToDate(const std::string &Topic,
+                      const std::string &isoDate) override;
 };
 }

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -60,7 +60,7 @@ void RequestHandler::checkConsumerModeArguments(bool TerminateAtEndOfTopic) {
       // consume from offset/date
       else if (UserArguments.OffsetToStart > -2) {
         subscribeAndConsume(UserArguments.TopicName,
-                            UserArguments.OffsetToStart);
+                            UserArguments.OffsetToStart, TerminateAtEndOfTopic);
       } else {
         // consume last N
         if (UserArguments.PartitionToConsume != -1) {

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -206,7 +206,7 @@ std::string RequestHandler::timestampToReadable(const int64_t &Timestamp) {
   using namespace std;
   time_t Seconds = Timestamp / 1000;
   ctime(&Seconds);
-  istringstream iss(asctime(localtime(&Seconds)));
+  istringstream iss(asctime(gmtime(&Seconds)));
   vector<string> tokens{istream_iterator<string>{iss},
                         istream_iterator<string>{}};
   return fmt::format("{} {}-{}-{} {}.{}", tokens[0], tokens[2], tokens[1],

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -34,14 +34,14 @@ void RequestHandler::checkConsumerModeArguments(bool TerminateAtEndOfTopic) {
   if (UserArguments.GoBack == -2 && UserArguments.OffsetToStart == -2 &&
       UserArguments.TopicName.empty()) {
     throw ArgumentException("Please specify topic!");
-  } else if (UserArguments.GoBack == -2 && UserArguments.OffsetToStart == -2 &&
-             !UserArguments.TopicName.empty() &&
-             !UserArguments.ISODate.empty()) {
+  }
+  checkIfTopicEmpty(UserArguments.TopicName);
+  if (UserArguments.GoBack == -2 && UserArguments.OffsetToStart == -2 &&
+      !UserArguments.TopicName.empty() && !UserArguments.ISODate.empty()) {
     subscribeAndConsume(UserArguments.ISODate, UserArguments.TopicName, false);
   } else if (UserArguments.GoBack == -2 && UserArguments.OffsetToStart == -2) {
     printEntireTopic(UserArguments.TopicName, TerminateAtEndOfTopic);
   } else {
-    checkIfTopicEmpty(UserArguments.TopicName);
     if (UserArguments.GoBack > -2 && UserArguments.OffsetToStart > -2) {
       subscribeAndConsume(UserArguments.TopicName, UserArguments.GoBack,
                           UserArguments.PartitionToConsume,

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -270,7 +270,7 @@ void RequestHandler::subscribeAndConsume(const std::string &TopicName,
   FlatbuffersTranslator FlatBuffers(SchemaPath);
   int MessagesCounter = 0;
   while (EOFPartitionCounter < NumberOfPartitions &&
-         MessagesCounter <= NumberOfMessages) {
+         MessagesCounter <= NumberOfMessages - 1) {
     if (consumeSingleMessage(EOFPartitionCounter, FlatBuffers))
       MessagesCounter++;
   }

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -75,4 +75,6 @@ private:
   std::string timestampToReadable(const int64_t &Timestamp);
   bool consumeSingleMessage(int &EOFPartitionCounter,
                             FlatbuffersTranslator &FlatBuffers);
+  void subscribeAndConsume(const std::string &isoDate, const std::string &Topic,
+                           bool TerminateAtEndOfTopic);
 };

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -76,7 +76,9 @@ private:
   std::string timestampToReadable(const int64_t &Timestamp);
   bool consumeSingleMessage(int &EOFPartitionCounter,
                             FlatbuffersTranslator &FlatBuffers);
-  void subscribeAndConsume(const std::string &isoDate, const std::string &Topic,
-                           bool TerminateAtEndOfTopic);
-  void consumeSubscribed(const std::string &Topic, bool TerminateAtEndOfTopic);
+
+  void consumeAllSubscribed(const std::string &Topic,
+                            bool TerminateAtEndOfTopic);
+  void consumeNSubscribed(const std::string &Topic, int64_t NumberOfMessages);
+  int64_t getOffsetForDate(const std::string &Date, const std::string &Topic);
 };

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -49,7 +49,8 @@ public:
   void subscribeAndConsume(const std::string &TopicName, int64_t Offset,
                            bool TerminateAtEndOfTopic = false);
   void subscribeAndConsume(const std::string &TopicName,
-                           int64_t NumberOfMessages, int Partition);
+                           int64_t NumberOfMessages, int Partition,
+                           bool TerminateAtEndOfTopic);
 
   void subscribeAndConsume(const std::string &TopicName,
                            int64_t NumberOfMessages, int Partition,
@@ -77,4 +78,5 @@ private:
                             FlatbuffersTranslator &FlatBuffers);
   void subscribeAndConsume(const std::string &isoDate, const std::string &Topic,
                            bool TerminateAtEndOfTopic);
+  void consumeSubscribed(const std::string &Topic, bool TerminateAtEndOfTopic);
 };

--- a/src/UserArgumentsStruct.h
+++ b/src/UserArgumentsStruct.h
@@ -15,6 +15,7 @@ struct UserArgumentStruct {
   int PartitionToConsume = -1;
   int Indentation = 4;
 
+  std::string ISODate;
   bool ShowAllTopics = false;
   bool ConsumerMode = false;
   bool MetadataMode = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,8 +41,7 @@ int main(int argc, char **argv) {
       ->check(CLI::Range(int64_t(0), std::numeric_limits<int64_t>::max()));
   App.add_option("-d, --date", UserArguments.ISODate,
                  "Start consuming from a ISO8601 date, e.g. "
-                 "2019-07-05T08:18:14.366. Incorrect date will print entire "
-                 "topic.");
+                 "[2019-07-05T08:18:14.366].");
   App.add_option(
          "-i,--indentation", UserArguments.Indentation,
          "Number of spaces used as indentation. Range 0 - 20. 4 by default.")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@ int main(int argc, char **argv) {
                  "Start consuming from an offset. Combine with \"-g\" to "
                  "display range of messages with \"-o\" as lower offset.")
       ->check(CLI::Range(int64_t(0), std::numeric_limits<int64_t>::max()));
+  App.add_option("-d, --date",UserArguments.ISODate,"date");
   App.add_option(
          "-i,--indentation", UserArguments.Indentation,
          "Number of spaces used as indentation. Range 0 - 20. 4 by default.")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,10 @@ int main(int argc, char **argv) {
                  "Start consuming from an offset. Combine with \"-g\" to "
                  "display range of messages with \"-o\" as lower offset.")
       ->check(CLI::Range(int64_t(0), std::numeric_limits<int64_t>::max()));
-  App.add_option("-d, --date",UserArguments.ISODate,"date");
+  App.add_option("-d, --date", UserArguments.ISODate,
+                 "Start consuming from a ISO8601 date, e.g. "
+                 "2019-07-05T08:18:14.366. Incorrect date will print entire "
+                 "topic.");
   App.add_option(
          "-i,--indentation", UserArguments.Indentation,
          "Number of spaces used as indentation. Range 0 - 20. 4 by default.")

--- a/test/RequestHandlerTest.cpp
+++ b/test/RequestHandlerTest.cpp
@@ -34,7 +34,7 @@ TEST(RequestHandlerTest, subscribe_consume_n_last_messages_successful_test) {
       UserArguments, updateSchemas(UpdateFromGithub), UseRealKafkaConnection);
 
   EXPECT_NO_THROW(
-      NewRequestHandler.subscribeAndConsume("ExampleTestTopic", 1, 1));
+      NewRequestHandler.subscribeAndConsume("ExampleTestTopic", 1, 1, true));
 }
 
 TEST(RequestHandlerTest,

--- a/test/RequestHandlerTest.cpp
+++ b/test/RequestHandlerTest.cpp
@@ -146,6 +146,7 @@ TEST(RequestHandlerTest,
   UserArguments.OffsetToStart = 1234;
   UserArguments.GoBack = 2;
   UserArguments.ConsumerMode = true;
+  UserArguments.TopicName = "MULTIPART_events";
 
   RequestHandler NewRequestHandler(
       UserArguments, updateSchemas(UpdateFromGithub), UseRealKafkaConnection);
@@ -158,11 +159,13 @@ TEST(RequestHandlerTest, subscribe_to_nlastmessages_no_error) {
   UserArguments.OffsetToStart = -1234;
   UserArguments.PartitionToConsume = 1;
   UserArguments.ConsumerMode = true;
+  UserArguments.GoBack = 2;
+  UserArguments.TopicName = "MULTIPART_events";
 
   RequestHandler NewRequestHandler(
       UserArguments, updateSchemas(UpdateFromGithub), UseRealKafkaConnection);
 
-  EXPECT_NO_THROW(NewRequestHandler.checkConsumerModeArguments());
+  EXPECT_NO_THROW(NewRequestHandler.checkConsumerModeArguments(true));
 }
 
 TEST(RequestHandlerTest,

--- a/test/RequestHandlerTest.cpp
+++ b/test/RequestHandlerTest.cpp
@@ -154,12 +154,49 @@ TEST(RequestHandlerTest,
   EXPECT_NO_THROW(NewRequestHandler.checkConsumerModeArguments());
 }
 
+TEST(RequestHandlerTest, consume_from_date_success) {
+  UserArgumentStruct UserArguments;
+  UserArguments.ConsumerMode = true;
+  UserArguments.ISODate = "2019-07-05T15:18:14";
+  UserArguments.TopicName = "MULTIPART_events";
+
+  RequestHandler NewRequestHandler(
+      UserArguments, updateSchemas(UpdateFromGithub), UseRealKafkaConnection);
+  EXPECT_NO_THROW(NewRequestHandler.checkConsumerModeArguments(true));
+}
+
+TEST(RequestHandlerTest, throw_error_if_date_and_offset_specified) {
+  UserArgumentStruct UserArguments;
+  UserArguments.ConsumerMode = true;
+  UserArguments.ISODate = "2019-07-05T15:18:14";
+  UserArguments.TopicName = "MULTIPART_events";
+  UserArguments.OffsetToStart = 2;
+  RequestHandler NewRequestHandler(
+      UserArguments, updateSchemas(UpdateFromGithub), UseRealKafkaConnection);
+  EXPECT_THROW(NewRequestHandler.checkConsumerModeArguments(true),
+               ArgumentException);
+}
+
 TEST(RequestHandlerTest, subscribe_to_nlastmessages_no_error) {
   UserArgumentStruct UserArguments;
   UserArguments.OffsetToStart = -1234;
   UserArguments.PartitionToConsume = 1;
   UserArguments.ConsumerMode = true;
   UserArguments.GoBack = 2;
+  UserArguments.TopicName = "MULTIPART_events";
+
+  RequestHandler NewRequestHandler(
+      UserArguments, updateSchemas(UpdateFromGithub), UseRealKafkaConnection);
+
+  EXPECT_NO_THROW(NewRequestHandler.checkConsumerModeArguments(true));
+}
+
+TEST(RequestHandlerTest, subscribe_to_nlastmessages_error_too_many_messages) {
+  UserArgumentStruct UserArguments;
+  UserArguments.OffsetToStart = -1234;
+  UserArguments.PartitionToConsume = 1;
+  UserArguments.ConsumerMode = true;
+  UserArguments.GoBack = 100;
   UserArguments.TopicName = "MULTIPART_events";
 
   RequestHandler NewRequestHandler(

--- a/test/RequestHandlerTest.cpp
+++ b/test/RequestHandlerTest.cpp
@@ -202,7 +202,8 @@ TEST(RequestHandlerTest, subscribe_to_nlastmessages_error_too_many_messages) {
   RequestHandler NewRequestHandler(
       UserArguments, updateSchemas(UpdateFromGithub), UseRealKafkaConnection);
 
-  EXPECT_NO_THROW(NewRequestHandler.checkConsumerModeArguments(true));
+  EXPECT_THROW(NewRequestHandler.checkConsumerModeArguments(true),
+               ArgumentException);
 }
 
 TEST(RequestHandlerTest,


### PR DESCRIPTION
### Description of work

Added option `-d ` `--date` that allows to specify ISO8601 date that is later translated to offset and used exactly the same way the `-o` value would be used.
A user can print messages from date, and a range of messages defined by date and  `-g` parameter.
Did some refactoring in `RequestHandler.cpp`.

### Issue

Closes #93 

### Acceptance Criteria

Would be good to try to test it with edge cases and multipart topics?

### Unit Tests

Added tests in `RequestHandlerTests` to cover new functionality, updated/modified some older ones.

