### PR TITLE
Print iso8601 timestamp

### DIFF
--- a/src/Kafka/MessageMetadataStruct.h
+++ b/src/Kafka/MessageMetadataStruct.h
@@ -12,6 +12,7 @@ struct MessageMetadataStruct {
   std::string Payload;
   bool PartitionEOF = false;
   std::string TimestampISO;
+  std::string TimestampISO8601;
   std::string Key;
   bool KeyPresent = false;
 };

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -76,7 +76,7 @@ private:
   std::string timestampToReadable(const int64_t &Timestamp);
   bool consumeSingleMessage(int &EOFPartitionCounter,
                             FlatbuffersTranslator &FlatBuffers);
-
+  std::string timestampToISO8601(const int64_t &Timestamp);
   void consumeAllSubscribed(const std::string &Topic,
                             bool TerminateAtEndOfTopic);
   void consumeNSubscribed(const std::string &Topic, int64_t NumberOfMessages);


### PR DESCRIPTION
### Description of work
Timestamp is displayed as ISO8601, exactly in a form that is taken as a parameter `--date` to allow for easy copy-paste.

Because ISO8601 is not easy to read the old one is still in use:
`Wed 26-Jun-2019 09:20:31.657  ||  2019-06-26T09:20:31.657   `

### Issue

Closes #95 