### PR TITLE
Check if topic exists

### DIFF
--- a/src/Kafka/Consumer.cpp
+++ b/src/Kafka/Consumer.cpp
@@ -112,7 +112,7 @@ Consumer::getTopicPartitionNumbers(const std::string &Topic) {
                                  return tpc->topic() == Topic;
                                });
   auto MatchedTopic = *Iterator;
-  if (MatchedTopic == nullptr)
+  if (MatchedTopic == *Topics->cend())
     throw ArgumentException(fmt::format("No such topic: {}", Topic));
 
   std::vector<int32_t> TopicPartitionNumbers;


### PR DESCRIPTION
### Description of work

Changed the way iterator is checked after looking through metadata to find if a topic exists.
It didn't work because in case nothing was found `find_if()` returns pointer to the end of an array, not nullptr.

### Issue

Closes #99 
More importantly I really wanted to get PR #100.

### Acceptance Criteria

Look for a nonexistent topic within a broker.

### Unit Tests

n/a

### Other

*Give information on anything else that might be relevant to the reviewer. Such as added system tests, update documentation etc.*

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).