### PR TITLE
Allow kafka config to be set via command line option

### DIFF
--- a/src/Kafka/Consumer.cpp
+++ b/src/Kafka/Consumer.cpp
@@ -39,11 +39,13 @@ std::unique_ptr<RdKafka::Metadata> Consumer::queryMetadata() {
   return metadata;
 }
 
-Consumer::Consumer(std::string Broker) : Logger(spdlog::get("LOG")) {
+Consumer::Consumer(const std::string &Broker,
+                   const std::map<std::string, std::string> &KafkaConfiguration)
+    : Logger(spdlog::get("LOG")) {
   std::string ErrStr;
   KafkaConsumer =
       std::shared_ptr<RdKafka::KafkaConsumer>(RdKafka::KafkaConsumer::create(
-          createGlobalConfiguration(Broker).get(), ErrStr));
+          createGlobalConfiguration(Broker, KafkaConfiguration).get(), ErrStr));
   if (!ErrStr.empty()) {
     ErrStr.append("Error creating KafkaConsumer in Consumer::Consumer.");
     Logger->error(ErrStr);

--- a/src/Kafka/Consumer.h
+++ b/src/Kafka/Consumer.h
@@ -8,7 +8,8 @@ namespace Kafka {
 
 class Consumer : public ConsumerInterface {
 public:
-  explicit Consumer(std::string Broker);
+  Consumer(const std::string &Broker,
+           const std::map<std::string, std::string> &KafkaConfiguration);
 
   ~Consumer() override {
     if (KafkaConsumer) {

--- a/src/Kafka/ConsumerFactory.cpp
+++ b/src/Kafka/ConsumerFactory.cpp
@@ -3,10 +3,12 @@
 
 namespace Kafka {
 
-std::unique_ptr<ConsumerInterface> createConsumer(const std::string &Broker,
-                                                  bool Real) {
+std::unique_ptr<ConsumerInterface>
+createConsumer(const std::string &Broker,
+               const std::map<std::string, std::string> &KafkaConfiguration,
+               bool Real) {
   if (Real) {
-    return std::make_unique<Consumer>(Broker);
+    return std::make_unique<Consumer>(Broker, KafkaConfiguration);
   } else {
     return std::make_unique<FakeConsumer>(FakeConsumer());
   }

--- a/src/Kafka/ConsumerFactory.h
+++ b/src/Kafka/ConsumerFactory.h
@@ -4,6 +4,8 @@
 #include <memory>
 
 namespace Kafka {
-std::unique_ptr<ConsumerInterface> createConsumer(const std::string &Broker,
-                                                  bool Real = true);
+std::unique_ptr<ConsumerInterface>
+createConsumer(const std::string &Broker,
+               const std::map<std::string, std::string> &KafkaConfiguration,
+               bool Real = true);
 }

--- a/src/Kafka/KafkaConfig.h
+++ b/src/Kafka/KafkaConfig.h
@@ -17,19 +17,16 @@ void setConfig(RdKafka::Conf &conf, const std::string &ConfigName,
   }
 }
 
-std::unique_ptr<RdKafka::Conf>
-createGlobalConfiguration(const std::string &BrokerAddr) {
+std::unique_ptr<RdKafka::Conf> createGlobalConfiguration(
+    const std::string &BrokerAddr,
+    const std::map<std::string, std::string> &KafkaConfiguration) {
   auto conf = std::unique_ptr<RdKafka::Conf>(
       RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL));
 
+  for (const auto &ConfigItem : KafkaConfiguration) {
+    setConfig(*conf, ConfigItem.first, ConfigItem.second);
+  }
   setConfig(*conf, "metadata.broker.list", BrokerAddr);
-  setConfig(*conf, "session.timeout.ms", "10000");
-  setConfig(*conf, "message.max.bytes", "10000000");
-  setConfig(*conf, "fetch.message.max.bytes", "10000000");
-  setConfig(*conf, "enable.auto.commit", "false");
-  setConfig(*conf, "enable.auto.offset.store", "false");
-  setConfig(*conf, "api.version.request", "true");
-  setConfig(*conf, "auto.offset.reset", "largest");
   // kafkacow uses assign not subscribe, so group id is not used for consumer
   // balancing.
   setConfig(*conf, "group.id", "kafkacow");

--- a/src/Kafka/Producer.cpp
+++ b/src/Kafka/Producer.cpp
@@ -1,16 +1,16 @@
 #include "Producer.h"
 #include "KafkaConfig.h"
 #include <memory>
-#include <sstream>
 
 namespace Kafka {
 
-Producer::Producer(std::string Broker, std::string Topic)
-    : TopicToProduce(Topic) {
+Producer::Producer(const std::string &Broker, std::string Topic,
+                   const std::map<std::string, std::string> &KafkaConfiguration)
+    : TopicToProduce(std::move(Topic)) {
   std::string ErrStr;
   this->KafkaProducer =
       std::shared_ptr<RdKafka::Producer>(RdKafka::Producer::create(
-          createGlobalConfiguration(Broker).get(), ErrStr));
+          createGlobalConfiguration(Broker, KafkaConfiguration).get(), ErrStr));
   if (!ErrStr.empty()) {
     ErrStr.append("Error creating KafkaProducer in Kafka::Producer::Producer.");
     Logger->error(ErrStr);

--- a/src/Kafka/Producer.h
+++ b/src/Kafka/Producer.h
@@ -2,6 +2,7 @@
 
 #include "ProducerInterface.h"
 #include <librdkafka/rdkafkacpp.h>
+#include <map>
 #include <spdlog/logger.h>
 #include <spdlog/spdlog.h>
 
@@ -9,9 +10,10 @@ namespace Kafka {
 
 class Producer : public ProducerInterface {
 public:
-  Producer(std::string Broker, std::string Topic);
+  Producer(const std::string &Broker, std::string Topic,
+           const std::map<std::string, std::string> &KafkaConfiguration);
 
-  ~Producer() {
+  ~Producer() override {
     if (KafkaProducer) {
       KafkaProducer->flush(500);
       RdKafka::wait_destroyed(5000);

--- a/src/Kafka/ProducerFactory.cpp
+++ b/src/Kafka/ProducerFactory.cpp
@@ -5,9 +5,11 @@
 namespace Kafka {
 
 std::unique_ptr<ProducerInterface>
-createProducer(const std::string &Broker, const std::string &Topic, bool Real) {
+createProducer(const std::string &Broker, const std::string &Topic,
+               const std::map<std::string, std::string> &KafkaConfiguration,
+               bool Real) {
   if (Real) {
-    return std::make_unique<Producer>(Broker, Topic);
+    return std::make_unique<Producer>(Broker, Topic, KafkaConfiguration);
   } else {
     return std::make_unique<FakeProducer>(FakeProducer());
   }

--- a/src/Kafka/ProducerFactory.h
+++ b/src/Kafka/ProducerFactory.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "Producer.h"
+#include <map>
 #include <memory>
 
 namespace Kafka {
-std::unique_ptr<ProducerInterface> createProducer(const std::string &Broker,
-                                                  const std::string &Topic,
-                                                  bool Real = true);
+std::unique_ptr<ProducerInterface>
+createProducer(const std::string &Broker, const std::string &Topic,
+               const std::map<std::string, std::string> &KafkaConfiguration,
+               bool Real = true);
 }

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -27,10 +27,12 @@ public:
                               !UserArguments.MetadataMode;
 
     if (ConsumerModeChosen || MetadataModeChosen) {
-      KafkaConsumer = Kafka::createConsumer(UserArguments.Broker, Real);
+      KafkaConsumer = Kafka::createConsumer(
+          UserArguments.Broker, UserArguments.KafkaConfiguration, Real);
     } else if (ProducerModeChosen) {
-      KafkaProducer = Kafka::createProducer(UserArguments.Broker,
-                                            UserArguments.TopicName, Real);
+      KafkaProducer =
+          Kafka::createProducer(UserArguments.Broker, UserArguments.TopicName,
+                                UserArguments.KafkaConfiguration, Real);
     } else {
       throw ArgumentException("Program can run in one and only one mode: "
                               "--consumer, --metadata or --producer");

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -16,24 +16,25 @@ public:
                           std::string FullSchemaPath, bool Real = true)
       : Logger(spdlog::get("LOG")), UserArguments(UserArguments),
         SchemaPath(std::move(FullSchemaPath)) {
-    // check input if ConsumerMode chosen
-    if (UserArguments.ConsumerMode && !UserArguments.MetadataMode &&
-        !UserArguments.ProducerMode) {
+    bool ConsumerModeChosen = UserArguments.ConsumerMode &&
+                              !UserArguments.MetadataMode &&
+                              !UserArguments.ProducerMode;
+    bool MetadataModeChosen = !UserArguments.ConsumerMode &&
+                              UserArguments.MetadataMode &&
+                              !UserArguments.ProducerMode;
+    bool ProducerModeChosen = UserArguments.ProducerMode &&
+                              !UserArguments.ConsumerMode &&
+                              !UserArguments.MetadataMode;
+
+    if (ConsumerModeChosen || MetadataModeChosen) {
       KafkaConsumer = Kafka::createConsumer(UserArguments.Broker, Real);
-    }
-    // check input if MetadataMode chosen
-    else if (!UserArguments.ConsumerMode && UserArguments.MetadataMode &&
-             !UserArguments.ProducerMode) {
-      KafkaConsumer = Kafka::createConsumer(UserArguments.Broker, Real);
-    } else if (UserArguments.ProducerMode && !UserArguments.ConsumerMode &&
-               !UserArguments.MetadataMode) {
+    } else if (ProducerModeChosen) {
       KafkaProducer = Kafka::createProducer(UserArguments.Broker,
                                             UserArguments.TopicName, Real);
-    }
-    // no MetadataMode or ConsumerMode chosen
-    else
+    } else {
       throw ArgumentException("Program can run in one and only one mode: "
                               "--consumer, --metadata or --producer");
+    }
   }
 
   void checkAndRun();

--- a/src/UserArgumentsStruct.h
+++ b/src/UserArgumentsStruct.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <string>
 
 struct UserArgumentStruct {
@@ -14,6 +15,21 @@ struct UserArgumentStruct {
 
   int PartitionToConsume = -1;
   int Indentation = 2;
+
+  std::map<std::string, std::string> KafkaConfiguration = {
+      {"metadata.request.timeout.ms", "2000"},
+      {"socket.timeout.ms", "10000"},
+      {"message.max.bytes", "100000000"},
+      {"fetch.message.max.bytes", "100000000"},
+      {"fetch.max.bytes", "100000000"},
+      {"receive.message.max.bytes",
+       "100000512"}, // must be at least fetch.max.bytes + 512
+      {"queue.buffering.max.ms", "50"},
+      {"api.version.request", "true"},
+      {"enable.auto.commit", "false"},
+      {"enable.auto.offset.store", "false"},
+      {"auto.offset.reset", "largest"},
+      {"session.timeout.ms", "10000"}};
 
   std::string ISODate;
   bool ShowAllTopics = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@ CLI::Option *addKafkaOption(CLI::App &App, std::string const &Name,
                             std::string const &Description,
                             bool Defaulted = false) {
   CLI::callback_t Fun = [&ConfigMap](CLI::results_t Results) {
+    // Loop through key-value pairs
     for (size_t i = 0; i < Results.size() / 2; i++) {
       ConfigMap[Results.at(i * 2)] = Results.at(i * 2 + 1);
     }


### PR DESCRIPTION
### Description of work

Allows any Kafka configuration property to be given as a command line argument.
Uses `-X` flag to match kafkacat interface.

### Issue

Closes #120
DM-1956

### To Test

Grab this docker compose file: https://github.com/ess-dmsc/udderly-secure/blob/master/docker-compose.yml
Do `docker-compose up`.

Try running
```
kafkacow -L -b localhost:9093
```
it will fail because authentication is enabled so credentials need to be set in the Kafka configuration.
Using the new feature should work:
```
kafkacow -b localhost:9093 -L -X security.protocol SASL_PLAINTEXT sasl.mechanisms PLAIN sasl.username udder sasl.password udder-secret
```

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).