### PR TITLE
Make archived artefact use static libraries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,6 +228,8 @@ def get_macos_pipeline()
 
                 dir("${project}/build") {
                     try {
+                        # Workaround for issue due to case-sensitivity in package names.
+                        sh "conan remove --force 'cli11*'
                         sh "conan install --build=outdated ../code"
                         sh "source activate_run.sh && cmake ../code"
                     } catch (e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ builders = pipeline_builder.createBuilders { container ->
   }  // stage
 
   // Use static libraries for archived artefact
-  if (container_key == release_os) {
+  if (container.key == release_os) {
     container.sh """
       cd ${pipeline_builder.project}
       sed -i 's/shared=True/shared=False/' conanfile.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,7 +228,7 @@ def get_macos_pipeline()
 
                 dir("${project}/build") {
                     try {
-                        # Workaround for issue due to case-sensitivity in package names.
+                        // Workaround for issue due to case-sensitivity in package names.
                         sh "conan remove --force 'cli11*'
                         sh "conan install --build=outdated ../code"
                         sh "source activate_run.sh && cmake ../code"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -229,7 +229,7 @@ def get_macos_pipeline()
                 dir("${project}/build") {
                     try {
                         // Workaround for issue due to case-sensitivity in package names.
-                        sh "conan remove --force 'cli11*'
+                        sh "conan remove --force 'cli11*'"
                         sh "conan install --build=outdated ../code"
                         sh "source activate_run.sh && cmake ../code"
                     } catch (e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,15 @@ builders = pipeline_builder.createBuilders { container ->
     container.copyTo(pipeline_builder.project, pipeline_builder.project)
   }  // stage
 
+  // Use static libraries for archived artefact
+  if (container_key == release_os) {
+    container.sh """
+      cd ${pipeline_builder.project}
+      sed -i 's/shared=True/shared=False/' conanfile.txt
+      cat conanfile.txt
+    """
+  }
+
   pipeline_builder.stage("${container.key}: get dependencies") {
     container.sh """
       mkdir build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,7 +98,6 @@ builders = pipeline_builder.createBuilders { container ->
         cd archive
         mkdir -p ${pipeline_builder.project}/bin
         cp ../build/bin/kafkacow ${pipeline_builder.project}/bin/
-        cp -r ../build/lib ${pipeline_builder.project}/
         cp -r ../build/licenses ${pipeline_builder.project}/
         cp -r ../build/schemas ${pipeline_builder.project}/
 


### PR DESCRIPTION
### Description of work

This makes deploying it simpler.

### Issue

n/a

### Acceptance Criteria

The archived artefact should now be statically linked to the external libraries we use.

### Unit Tests

n/a

### Other

I also added a workaround for a macOS build issue due to the existence of both a cli11 and a CLI11 Conan packages.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).